### PR TITLE
Add import_json function, deprecate JSON_Object

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -76,6 +76,9 @@ API Changes:
   :class:`~klibs.KLGraphics.NumpySurface` class. For rotating images at anything
   other than 90-degree angles, please use the ``Image`` class from the Pillow
   library instead.
+* Invalid key names for :class:`~klibs.KLJSON_Object.KLJSON_Object` now raise a
+  ``ValueError`` instead of a ``RuntimeError``. Conversely, importing a
+  malformed JSON file now raises a ``RuntimeError`` instead of a ``ValueError``.
 
 
 Fixed Bugs:
@@ -86,3 +89,5 @@ Fixed Bugs:
   reliably catching quit events.
 * Fixed runtime info detection on macOS Big Sur and later.
 * Rewrote the broken NumpySurface `scale` method to be usable.
+* Improved reliability of checks in :class:`~klibs.KLJSON_Object.KLJSON_Object`
+  that verify all JSON keys are valid Python attribute names.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -76,9 +76,8 @@ API Changes:
   :class:`~klibs.KLGraphics.NumpySurface` class. For rotating images at anything
   other than 90-degree angles, please use the ``Image`` class from the Pillow
   library instead.
-* Invalid key names for :class:`~klibs.KLJSON_Object.KLJSON_Object` now raise a
-  ``ValueError`` instead of a ``RuntimeError``. Conversely, importing a
-  malformed JSON file now raises a ``RuntimeError`` instead of a ``ValueError``.
+* :class:`~klibs.KLJSON_Object.KLJSON_Object` has been deprecated in favour of a
+  new JSON import function, :func:`~klibs.KLJSON_Object.import_json`.
 
 
 Fixed Bugs:

--- a/klibs/KLCommunication.py
+++ b/klibs/KLCommunication.py
@@ -17,7 +17,7 @@ from sdl2 import (SDL_PumpEvents, SDL_StartTextInput, SDL_StopTextInput,
 from klibs.KLConstants import (AUTO_POS, BL_CENTER, BL_TOP_LEFT, QUERY_ACTION_UPPERCASE,
 	QUERY_ACTION_HASH)
 import klibs.KLParams as P
-from klibs.KLJSON_Object import JSON_Object, AttributeDict
+from klibs.KLJSON_Object import import_json, AttributeDict
 from klibs.KLUtilities import pretty_list, now, pump, flush, iterable, utf8, make_hash
 from klibs.KLUtilities import colored_stdout as cso
 from klibs.KLDatabase import EntryTemplate
@@ -142,7 +142,7 @@ def init_messaging():
 
 	# Load the user_queries file in and store the queries in an object
 	try:
-		user_queries = JSON_Object(P.user_queries_file_path)
+		user_queries = import_json(P.user_queries_file_path)
 		# After loading in queries, verify that all required sections are present
 		required_sections = ['default_strings', 'demographic', 'experimental']
 		for req in required_sections:

--- a/klibs/KLJSON_Object.py
+++ b/klibs/KLJSON_Object.py
@@ -6,14 +6,14 @@ import json
 
 
 class AttributeDict(dict):
-	'''A Python dictionary that lets you access items like you would object attributes.
+	"""A Python dictionary that lets you access items like you would object attributes.
 	For example, for the following AttributeDict::
 	
 		 d = {'one': 1, 'two': 2}
 	
 	you could get the value of 'one' through either d['one'] or d.one.
 	
-	'''
+	"""
 	def __getattr__(self, key):
 		return self[key]
 
@@ -22,7 +22,7 @@ class AttributeDict(dict):
 
 
 class JSON_Object(AttributeDict):
-	'''A class for importing JSON objects such that you can access their attributes the same way
+	"""A class for importing JSON objects such that you can access their attributes the same way
 	you would a Python object. For example, if you imported a .json file with the following
 	contents:
 	
@@ -64,7 +64,7 @@ class JSON_Object(AttributeDict):
 	Args:
 		json_file_path (:obj:`str`): The path of the JSON file to import.
 
-	'''
+	"""
 
 	def __init__(self, json_file_path):
 		try:
@@ -73,14 +73,17 @@ class JSON_Object(AttributeDict):
 			for key in json_dict:
 				setattr(self, key, json_dict[key])
 		except ValueError:
-			raise ValueError("JSON file is poorly formatted. Please check syntax.")
+			err = "'{0}' is not a valid JSON file.".format(json_file_path)
+			raise RuntimeError(err)
+		except AttributeError as e:
+			raise ValueError(e)
 	
 	def __objectify(self, dict_obj):
 		# Check if JSON object name is a valid Python class attribute name
-		valid_attr_name = re.compile(r"[A-Za-z_](?:[A-Za-z0-9_]{2,30})?|(__.*__)")
+		valid_attr_name = re.compile(r"^[A-Za-z_]+([A-Za-z0-9_]+)?$")
 		for key in dict_obj.keys():
 			if re.match(valid_attr_name, key) == None:
-				print(u"Error: '{0}' is not a valid Python class attribute name ".format(key) +
-					u"(try removing special characters).\n")
-				raise RuntimeError("Error encountered loading json_object")
+				e = u"'{0}' is not a valid Python class attribute name ".format(key)
+				e += u"(try removing spaces and special characters)."
+				raise AttributeError(e)
 		return AttributeDict(dict_obj)

--- a/klibs/tests/test_KLJSON_Object.py
+++ b/klibs/tests/test_KLJSON_Object.py
@@ -40,7 +40,7 @@ def test_JSON_Object(tmpdir):
     assert t1.one.b == None
 
     # Test checking for bad variable names
-    test2 = tmpdir.join("test3.json")
+    test2 = tmpdir.join("test2.json")
     test2.write("""
     {
         "invalid name": 5,
@@ -48,7 +48,7 @@ def test_JSON_Object(tmpdir):
     }
     """)
     testpath = os.path.join(test2.dirname, test2.basename)
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         t2 = json_obj.JSON_Object(testpath)
 
     # Test error handling of non-JSON files
@@ -61,3 +61,70 @@ def test_JSON_Object(tmpdir):
     testpath = os.path.join(test3.dirname, test3.basename)
     with pytest.raises(RuntimeError):
         t3 = json_obj.JSON_Object(testpath)
+
+
+def test_import_json(tmpdir):
+
+    # Test importing a normal unicode JSON file
+    test1 = tmpdir.join("test1.json")
+    test1.write(u"""
+    {
+        "one": {
+            "a": false,
+            "b": null,
+            "c": [1, 2, 3, 4, 5]
+        },
+        "two": "hello",
+        "three": "well done 測試 ✓"
+    }
+    """.encode('utf-8'), mode='wb')
+    testpath = os.path.join(test1.dirname, test1.basename)
+    t1 = json_obj.import_json(testpath)
+    assert isinstance(t1.one, dict)
+    assert t1.two == "hello"
+    assert sum(t1.one.c) == 15
+    assert not t1['one'].a
+    assert t1.one.b == None
+
+    test2 = tmpdir.join("test2.json")
+    test2.write(u"""
+    [
+        {
+            "a": false,
+            "b": null,
+            "c": [1, 2, 3, 4, 5]
+        },
+        "hello",
+        [1, 2, 3]
+    ]
+    """.encode('utf-8'), mode='wb')
+    testpath = os.path.join(test2.dirname, test2.basename)
+    t2 = json_obj.import_json(testpath)
+    assert isinstance(t2[0], dict)
+    assert t2[1] == "hello"
+    assert sum(t2[0].c) == 15
+    assert not t2[0]["a"]
+    assert sum(t2[2]) == 6
+
+    # Test checking for bad variable names
+    test3 = tmpdir.join("test3.json")
+    test3.write("""
+    {
+        "invalid name": 5,
+        "2": "hello"
+    }
+    """)
+    testpath = os.path.join(test3.dirname, test3.basename)
+    with pytest.raises(ValueError):
+        t3 = json_obj.import_json(testpath)
+
+    # Test error handling of non-JSON files
+    test4 = tmpdir.join("test4.json")
+    test4.write("""
+    [this is not a json file]
+    not = a
+    json != file
+    """)
+    testpath = os.path.join(test4.dirname, test4.basename)
+    with pytest.raises(RuntimeError):
+        t4 = json_obj.import_json(testpath)

--- a/klibs/tests/test_KLJSON_Object.py
+++ b/klibs/tests/test_KLJSON_Object.py
@@ -48,7 +48,7 @@ def test_JSON_Object(tmpdir):
     }
     """)
     testpath = os.path.join(test2.dirname, test2.basename)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AttributeError):
         t2 = json_obj.JSON_Object(testpath)
 
     # Test error handling of non-JSON files
@@ -59,5 +59,5 @@ def test_JSON_Object(tmpdir):
     json != file
     """)
     testpath = os.path.join(test3.dirname, test3.basename)
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         t3 = json_obj.JSON_Object(testpath)


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR deprecates the `JSON_Object` class in favour of a more flexible function (`import_json`) that does the same thing. Apart from having a nicer name, the main advantage of this function is that it can import JSON files where the root is a list, which was impossible using the `JSON_Object`/class-based approach. `JSON_Object` is being left in for compatibility with existing code.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
