### PR TITLE
Remove use of the deprecated 'imp' module

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -91,3 +91,5 @@ Fixed Bugs:
 * Improved reliability of checks in :class:`~klibs.KLJSON_Object.KLJSON_Object`
   that verify all JSON keys are valid Python attribute names.
 * Fixed a bug preventing projects with underscores in their name from opening.
+* Removed dependency on the deprecated ``imp`` module for Python 3, removing
+  a runtime warning.

--- a/docs/markdown/Drawing.md
+++ b/docs/markdown/Drawing.md
@@ -252,6 +252,6 @@ You'll notice that the experiment exits itself after a couple key presses. This 
     ^
 IndentationError: unexpected indent
   File "/usr/local/bin/klibs", line 281, in run
-    experiment_file = imp.load_source(path, "experiment.py")
+    experiment = load_source("experiment.py")[project_name]
 ```
 This is because Python as a language is super-picky about whether you use tabs or spaces to indent lines because indentation is how you indicate that a loop has started or ended and many other things. If you copy and paste lines of code from the internet into a Python file you've written, it may use a different kind of indentation and confuse the Python interpreter. To avoid this, most text editors have a "convert tabs to spaces" or "convert spaces to tabs" function you can use to make it all consistent. It doesn't matter which one you use (tabs or spaces, that is, but spaces is recommended by the [official PEP8 style guide](https://www.python.org/dev/peps/pep-0008/)), the important thing is consistency.

--- a/klibs/KLEyeTracking/__init__.py
+++ b/klibs/KLEyeTracking/__init__.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
-import imp
 from klibs import P
-try:
-	imp.find_module('pylink')
-	PYLINK_AVAILABLE = True
-except ImportError:
-	print("\t* Warning: Pylink library not found; eye tracking will not be available.")
-	PYLINK_AVAILABLE = False
+from klibs.KLInternal import package_available
+
+PYLINK_AVAILABLE = package_available('pylink')
 
 if PYLINK_AVAILABLE and P.eye_tracker_available:
+	if P.development_mode:
+		print("* Pylink available, attempting to use EyeLink eye tracker...\n")
 	from .KLEyeLink import EyeLink as Tracker
-	if P.development_mode:
-		print("Using PyLink")
 else:
+	if P.eye_tracker_available:
+		print("* Warning: Pylink library not installed, falling back to TryLink\n")
+	elif P.development_mode:
+		print("* Using TryLink mouse simulation\n")
 	from .KLTryLink import TryLink as Tracker
-	if P.development_mode:
-		print("Using TryLink")

--- a/klibs/KLGraphics/KLDraw.py
+++ b/klibs/KLGraphics/KLDraw.py
@@ -1,7 +1,6 @@
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
 import abc
-from imp import load_source
 from bisect import bisect
 from os.path import join
 from math import cos, sin, radians, ceil, sqrt

--- a/klibs/KLInternal.py
+++ b/klibs/KLInternal.py
@@ -68,7 +68,7 @@ def iterable(obj, exclude_strings=True):
 
 
 def utf8(x):
-	'''A Python 2/3 agnostic function for converting things to unicode strings.
+	"""A Python 2/3 agnostic function for converting things to unicode strings.
     
     Equivalent to ``unicode()`` in Python 2 and ``str()`` in Python 3.
 	
@@ -78,11 +78,33 @@ def utf8(x):
 	Returns:
 		unicode or str: a unicode string in Python 2, and a regular (unicode) string in Python 3.
 	
-	'''
+	"""
 	try:
 		return unicode(x)
 	except NameError:
 		return str(x)
+
+
+def package_available(name):
+	"""Checks whether a given package is installed.
+
+    Written to be Python 2/3 agnostic.
+
+	Args:
+		name (str): Name of the Python package to search for.
+
+	Returns:
+		bool: True if the package is available, otherwise False.
+
+	"""
+	if sys.version_info.major == 3:
+		from importlib.util import find_spec
+	else:
+		from imp import find_module as find_spec
+	try:
+		return find_spec(name) != None
+	except (ValueError, ImportError):
+		return False
 
 
 def boolean_to_logical(value, convert_integers=False):

--- a/klibs/KLTrialFactory.py
+++ b/klibs/KLTrialFactory.py
@@ -6,9 +6,9 @@ from collections import OrderedDict
 from copy import copy, deepcopy
 from itertools import product
 from os.path import exists, join
-from imp import load_source
 		
 from klibs import P
+from klibs.KLInternal import load_source
 from klibs.KLIndependentVariable import IndependentVariableSet
 
 
@@ -114,8 +114,8 @@ class TrialFactory(object):
 
 		set_name = "{0}_ind_vars".format(P.project_name)
 		try:
-			var_set = load_source("*", path).__dict__[set_name]
-			factors = var_set.to_dict()
+			ind_vars = load_source(path)
+			factors = ind_vars[set_name].to_dict()
 		except KeyError:
 			err = 'Unable to find IndependentVariableSet in independent_vars.py.'
 			raise RuntimeError(err)

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -3,11 +3,11 @@ __author__ = 'Austin Hurst & Jonathan Mulle'
 import os
 import re
 import sys
-import imp
 import time
 import traceback
 
 from klibs.KLExceptions import DatabaseException
+from klibs.KLInternal import load_source
 from klibs.KLUtilities import colored_stdout as cso
 from klibs.KLUtilities import getinput
 from klibs import P
@@ -251,7 +251,7 @@ def run(screen_size, path, condition, devmode, no_tracker, seed):
 
 	# import params defined in project's local params file in ExpAssets/Config
 	try:
-		for k, v in imp.load_source("*", P.params_file_path).__dict__.items():
+		for k, v in load_source(P.params_file_path).items():
 			setattr(P, k, v)
 	except IOError:
 		err("Unable to locate the experiment's '_params.py' file. Please ensure that this "
@@ -260,7 +260,7 @@ def run(screen_size, path, condition, devmode, no_tracker, seed):
 
 	# if a local params file exists, do the same:
 	if os.path.exists(P.params_local_file_path) and not P.dm_ignore_local_overrides:
-		for k, v in imp.load_source("*", P.params_local_file_path).__dict__.items():
+		for k, v in load_source(P.params_local_file_path).items():
 			setattr(P, k, v)
 
 	# If a condition has been specified, make sure it's a valid condition as per params.py
@@ -308,8 +308,7 @@ def run(screen_size, path, condition, devmode, no_tracker, seed):
 		init_messaging()
 
 		# finally, import the project's Experiment class and instantiate
-		experiment_file = imp.load_source(path, "experiment.py")
-		experiment = getattr(experiment_file, project_name)
+		experiment = load_source("experiment.py")[project_name]
 		env.exp = experiment()
 
 		# create a display context if everything's gone well so far
@@ -348,7 +347,7 @@ def export(path, table=None, combined=False, join=None):
 		os.makedirs(P.incomplete_data_dir)
 
 	# import params defined in project's local params file in ExpAssets/Config
-	for k, v in imp.load_source("*", P.params_file_path).__dict__.items():
+	for k, v in load_source(P.params_file_path).items():
 		setattr(P, k, v)
 	multi_file = combined != True
 	DatabaseManager().export(table, multi_file, join)
@@ -365,7 +364,7 @@ def rebuild_db(path):
 	P.setup(project_name)
 
 	# import params defined in project's local params file in ExpAssets/Config
-	for k, v in imp.load_source("*", P.params_file_path).__dict__.items():
+	for k, v in load_source(P.params_file_path).items():
 		setattr(P, k, v)
 	DatabaseManager().rebuild()
 


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR refactors the code used for 1) checking the availability of packages, and 2) importing the attributes from Python source files. The new code is fully compatible with Python 2 and 3, and also makes working with loading the attributes from `.py` files much easier and cleaner.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
