### PR TITLE
Clean up and extend the KLBoundary module

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -47,13 +47,16 @@ New Features:
 * Added proper print methods for all built-in :obj:`~klibs.KLBoundary.Boundary`
   types.
 * Added a new argument ``ignore`` to the
-  :obj:`~klibs.KLBoundary.BoundaryInspector.which_boundary` method of the
+  :meth:`~klibs.KLBoundary.BoundaryInspector.which_boundary` method of the
   ``BoundaryInspector`` class, allowing easy exclusion of specific boundaries
   from the search and replacing the functionality of the now-removed
   ``disable_boundaries`` and ``enable_boundaries`` methods.
 * Added a new ``boundaries`` argument to the
   :obj:`~klibs.KLBoundary.BoundaryInspector` class to allow initializing an
   inspector with a given set of boundaries.
+* Added a new :attr:`~klibs.KLBoundary.BoundaryInspector.labels` attribute to
+  the ``BoundaryInspector`` class to easily retrieve the names of all
+  boundaries currently within the inspector.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -62,6 +62,8 @@ New Features:
   instead of ``if circle.within(point)``).
 * :obj:`~klibs.KLBoundary.Boundary` objects can now be relocated by setting
   their ``center`` attribute to a set of pixel coordinates.
+* :obj:`~klibs.KLBoundary.RectangleBoundary` objects now have ``height`` and
+  ``width`` attributes.
 
 
 API Changes:
@@ -109,6 +111,9 @@ API Changes:
   :obj:`~klibs.KLBoundary.BoundaryInspector` class.
 * Removed the convoluted ``bounds`` getter/setter attribute from all
   :obj:`~klibs.KLBoundary.Boundary` subclasses.
+* :obj:`~klibs.KLBoundary.RectangleBoundary` objects no longer raise an error
+  if ``p2`` is above or to the left of ``p1`` and instead swaps the x and y
+  values such that ``p1`` is always the top-leftmost coordinate.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -47,16 +47,16 @@ New Features:
 * Added proper print methods for all built-in :obj:`~klibs.KLBoundary.Boundary`
   types.
 * Added a new argument ``ignore`` to the
-  :meth:`~klibs.KLBoundary.BoundaryInspector.which_boundary` method of the
-  ``BoundaryInspector`` class, allowing easy exclusion of specific boundaries
+  :meth:`~klibs.KLBoundary.BoundarySet.which_boundary` method of the
+  ``BoundarySet`` class, allowing easy exclusion of specific boundaries
   from the search and replacing the functionality of the now-removed
   ``disable_boundaries`` and ``enable_boundaries`` methods.
 * Added a new ``boundaries`` argument to the
-  :obj:`~klibs.KLBoundary.BoundaryInspector` class to allow initializing an
-  inspector with a given set of boundaries.
-* Added a new :attr:`~klibs.KLBoundary.BoundaryInspector.labels` attribute to
-  the ``BoundaryInspector`` class to easily retrieve the names of all
-  boundaries currently within the inspector.
+  :obj:`~klibs.KLBoundary.BoundarySet` class to allow initializing a boundary
+  set with a given set of boundaries.
+* Added a new :attr:`~klibs.KLBoundary.BoundarySet.labels` attribute to
+  the ``BoundarySet`` class to easily retrieve the names of all
+  boundaries currently within the set.
 * Added support for using Python's ``in`` operator with
   :obj:`~klibs.KLBoundary.Boundary` objects (e.g. ``if point in circle``
   instead of ``if circle.within(point)``).
@@ -103,12 +103,14 @@ API Changes:
   tuples for storing/returning (x, y) pixel coordinates.
 * Removed the legacy ``shape`` attribute from :obj:`~klibs.KLBoundary.Boundary`
   (use ``isinstance`` to check boundary types instead).
-* :obj:`~klibs.KLBoundary.BoundaryInspector` methods now raise ``KeyError``
+* Renamed ``BoundaryInspector`` to :obj:`~klibs.KLBoundary.BoundarySet` to
+  better represent its purpose.
+* :obj:`~klibs.KLBoundary.BoundarySet` methods now raise ``KeyError``
   exceptions instead of ``BoundaryError`` exceptions when given a boundary label
-  that does not exist within the inspector.
+  that does not exist within the set.
 * Removed the ``enable_boundaries`` and ``disable_boundaries`` methods as well
   as the ``active_boundaries`` attribute from the 
-  :obj:`~klibs.KLBoundary.BoundaryInspector` class.
+  :obj:`~klibs.KLBoundary.BoundarySet` class.
 * Removed the convoluted ``bounds`` getter/setter attribute from all
   :obj:`~klibs.KLBoundary.Boundary` subclasses.
 * :obj:`~klibs.KLBoundary.RectangleBoundary` objects no longer raise an error
@@ -129,5 +131,5 @@ Fixed Bugs:
 * Fixed a bug preventing projects with underscores in their name from opening.
 * Removed dependency on the deprecated ``imp`` module for Python 3, removing
   a runtime warning.
-* Fixed :meth:`~klibs.KLBoundary.BoundaryInspector.clear_boundaries` to always
+* Fixed :meth:`~klibs.KLBoundary.BoundarySet.clear_boundaries` to always
   keep preserved boundaries in the same order as they were added.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -44,8 +44,13 @@ New Features:
   NumpySurface class for retrieving the current dimensions and midpoint of a
   surface, respectively.
 * Improved the loading speed of the ``klibs`` command line.
-* Added proper `repr` methods for all built-in :obj:`~klibs.KLBoundary.Boundary`
+* Added proper print methods for all built-in :obj:`~klibs.KLBoundary.Boundary`
   types.
+* Added a new argument ``ignore`` to the
+  :obj:`~klibs.KLBoundary.BoundaryInspector.which_boundary` method of the
+  ``BoundaryInspector`` class, allowing easy exclusion of specific boundaries
+  from the search and replacing the functionality of the now-removed
+  ``disable_boundaries`` and ``enable_boundaries`` methods.
 
 
 API Changes:
@@ -85,6 +90,12 @@ API Changes:
   tuples for storing/returning (x, y) pixel coordinates.
 * Removed the legacy ``shape`` attribute from :obj:`~klibs.KLBoundary.Boundary`
   (use ``isinstance`` to check boundary types instead).
+* :obj:`~klibs.KLBoundary.BoundaryInspector` methods now raise ``KeyError``
+  exceptions instead of ``BoundaryError`` exceptions when given a boundary label
+  that does not exist within the inspector.
+* Removed the ``enable_boundaries`` and ``disable_boundaries`` methods as well
+  as the ``active_boundaries`` attribute from the 
+  :obj:`~klibs.KLBoundary.BoundaryInspector` class.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -51,6 +51,9 @@ New Features:
   ``BoundaryInspector`` class, allowing easy exclusion of specific boundaries
   from the search and replacing the functionality of the now-removed
   ``disable_boundaries`` and ``enable_boundaries`` methods.
+* Added a new ``boundaries`` argument to the
+  :obj:`~klibs.KLBoundary.BoundaryInspector` class to allow initializing an
+  inspector with a given set of boundaries.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -107,6 +107,8 @@ API Changes:
 * Removed the ``enable_boundaries`` and ``disable_boundaries`` methods as well
   as the ``active_boundaries`` attribute from the 
   :obj:`~klibs.KLBoundary.BoundaryInspector` class.
+* Removed the convoluted ``bounds`` getter/setter attribute from all
+  :obj:`~klibs.KLBoundary.Boundary` subclasses.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -57,6 +57,9 @@ New Features:
 * Added a new :attr:`~klibs.KLBoundary.BoundaryInspector.labels` attribute to
   the ``BoundaryInspector`` class to easily retrieve the names of all
   boundaries currently within the inspector.
+* Added support for using Python's ``in`` operator with
+  :obj:`~klibs.KLBoundary.Boundary` objects (e.g. ``if point in circle``
+  instead of ``if circle.within(point)``).
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -124,3 +124,5 @@ Fixed Bugs:
 * Fixed a bug preventing projects with underscores in their name from opening.
 * Removed dependency on the deprecated ``imp`` module for Python 3, removing
   a runtime warning.
+* Fixed :meth:`~klibs.KLBoundary.BoundaryInspector.clear_boundaries` to always
+  keep preserved boundaries in the same order as they were added.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -44,6 +44,8 @@ New Features:
   NumpySurface class for retrieving the current dimensions and midpoint of a
   surface, respectively.
 * Improved the loading speed of the ``klibs`` command line.
+* Added proper `repr` methods for all built-in :obj:`~klibs.KLBoundary.Boundary`
+  types.
 
 
 API Changes:
@@ -79,6 +81,8 @@ API Changes:
   library instead.
 * :class:`~klibs.KLJSON_Object.KLJSON_Object` has been deprecated in favour of a
   new JSON import function, :func:`~klibs.KLJSON_Object.import_json`.
+* Standardized built-in :obj:`~klibs.KLBoundary.Boundary` types to always use
+  tuples for storing/returning (x, y) pixel coordinates.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -60,6 +60,8 @@ New Features:
 * Added support for using Python's ``in`` operator with
   :obj:`~klibs.KLBoundary.Boundary` objects (e.g. ``if point in circle``
   instead of ``if circle.within(point)``).
+* :obj:`~klibs.KLBoundary.Boundary` objects can now be relocated by setting
+  their ``center`` attribute to a set of pixel coordinates.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -83,6 +83,8 @@ API Changes:
   new JSON import function, :func:`~klibs.KLJSON_Object.import_json`.
 * Standardized built-in :obj:`~klibs.KLBoundary.Boundary` types to always use
   tuples for storing/returning (x, y) pixel coordinates.
+* Removed the legacy ``shape`` attribute from :obj:`~klibs.KLBoundary.Boundary`
+  (use ``isinstance`` to check boundary types instead).
 
 
 Fixed Bugs:

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -17,6 +17,8 @@ your own custom boundary shapes by subclassing the :class:`Boundary` object.
 
 """
 
+# NOTE: it would be much more sane for boundaries to only have labels when added to an inspector,
+#       but is there any way of changing this without breaking the API?
 
 class BoundaryInspector(object):
 	"""A class for managing and inspecting multiple :class:`Boundary` objects.
@@ -85,12 +87,13 @@ class BoundaryInspector(object):
 		self.boundaries[label] = b
 
 	def add_boundaries(self, boundaries):
-		"""Adds one or more boundaries to the inspector. Boundaries can either be lists in the
-		format [label, bounds, shape] (see :meth:`add_boundary` for more info) or :class:`Boundary`
-		objects (e.g. a :class:`RectangleBoundary`).
+		"""Adds multiple boundaries to the inspector.
+		
+		See :meth:`add_boundary` for more info.
 
 		Args:
-			boundaries (:obj:`List`): A list containing the boundaries to add to the inspector.
+			boundaries (:obj:`List`): A list of :obj:`Boundary` objects to add to the
+				inspector.
 		
 		"""
 		for b in boundaries:
@@ -104,15 +107,15 @@ class BoundaryInspector(object):
 
 		Args:
 			label (:obj:`str`): The label of the boundary to inspect.
-			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to check for the
-				presence of within the boundary.
+			p (:obj:`Tuple` or :obj:`List`): The (x, y) coordinates of the point to
+				check against the boundary.
 		
 		Returns:
 			bool: True if the point falls within the boundary, otherwise False.
 		
 		Raises:
 			KeyError: If no boundary with the given label exists within the inspector.
-			ValueError: If the given point is not a valid set of (x,y) coordinates.
+			ValueError: If the given point is not a valid set of (x, y) coordinates.
 		
 		"""
 		self.__verify_label(label)
@@ -133,7 +136,7 @@ class BoundaryInspector(object):
 		specific boundaries from the search using the ``ignore`` argument.
 
 		Args:
-			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to test
+			p (:obj:`Tuple` or :obj:`List`): The (x, y) coordinates of the point to test
 				against the inspector's boundaries.
 			labels (:obj:`List`, optional): A list containing the labels of the
 				boundaries to inspect. Defaults to inspecting all boundaries.
@@ -146,7 +149,7 @@ class BoundaryInspector(object):
 		
 		Raises:
 			KeyError: If any given labels do not correspond to a boundary within the inspector.
-			ValueError: If the given point is not a valid set of (x,y) coordinates.
+			ValueError: If the given point is not a valid set of (x, y) coordinates.
 		
 		"""
 		if not labels:
@@ -183,11 +186,11 @@ class BoundaryInspector(object):
 		"""Removes all boundaries from the inspector.
 
 		Args:
-			preserve (:obj:`List`, optional): A list containing the labels of any boundaries
-				that should remain in the inspector after the clear.
+			preserve (:obj:`List`, optional): A list containing the labels of any
+				boundaries that should remain in the inspector after the clear.
 
 		Raises:
-			KeyError: If any given labels do not correspond to boundaries within the inspector.
+			KeyError: If any label does not correspond to a boundary within the inspector.
 		
 		"""
 		if not iterable(preserve):
@@ -210,6 +213,9 @@ class BoundaryInspector(object):
 			labels (:obj:`List`, optional): A list containing the labels of the boundaries to draw.
 				If no labels are specified or labels == None, all enabled boundaries in the
 				inspector will be drawn.
+
+		Raises:
+			KeyError: If any label does not correspond to a boundary within the inspector.
 		
 		"""
 		raise NotImplementedError("Boundary drawing will be implemented in a future version.")
@@ -227,12 +233,12 @@ class Boundary(object):
 	"""An abstract base class defining the required properties of a boundary.
 	
 	You will only need to use this class if you want to create your own custom Boundary
-	type. To do this, you will need to subclass this class and override its `within`
-	and `center` methods. This will define the functions that check whether a point is
+	type. To do this, you will need to subclass this class and override its ``within``
+	and ``center`` methods. This will define the functions that check whether a point is
 	within the custom boundary and update the location of the boundary's center,
 	respectively.
 
-	In addition to the `within` method, you can also check if a point is within a
+	In addition to the ``within`` method, you can also check if a point is within a
 	boundary using Python's ``in`` operator::
 
 		boundary = CircleBoundary('start_button', center=(100, 100), radius=50)
@@ -269,10 +275,10 @@ class Boundary(object):
 
 	@property
 	def center(self):
-		""":obj:`Tuple`: The (x,y) coordinates of the center of the boundary.
+		""":obj:`Tuple`: The (x, y) coordinates of the center of the boundary.
 
 		Raises:
-			ValueError: If the given value is not a valid pair of (x,y) coordinates.
+			ValueError: If the given value is not a valid pair of (x, y) coordinates.
 
 		"""
 		return self.__center
@@ -286,14 +292,14 @@ class Boundary(object):
 		"""Determines whether a given point is within the boundary.
 
 		Args:
-			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to
+			p (:obj:`Tuple` or :obj:`List`): The (x, y) coordinates of the point to
 				check against the boundary.
 		
 		Returns:
 			bool: True if the point falls within the boundary, otherwise False.
 		
 		Raises:
-			ValueError: If the given point is not a valid set of (x,y) coordinates.
+			ValueError: If the given point is not a valid set of (x, y) coordinates.
 		
 		"""
 		raise NotImplementedError
@@ -306,11 +312,11 @@ class RectangleBoundary(Boundary):
 	
 	Args:
 		label (:obj:`str`): An informative label to use for the boundary.
-		p1 (:obj:`Tuple`): The (x,y) coordinates of the top-left corner of the boundary.
-		p2 (:obj:`Tuple`): The (x,y) coordinates of the bottom-right corner of the boundary.
+		p1 (:obj:`Tuple`): The (x, y) coordinates of the top-left corner of the boundary.
+		p2 (:obj:`Tuple`): The (x, y) coordinates of the bottom-right corner of the boundary.
 
 	Raises:
-		ValueError: If either p1 or p2 are not valid (x,y) coordinates.
+		ValueError: If either p1 or p2 are not valid (x, y) coordinates.
 		ValueError: If p2 (the bottom-right point) is above or to the left of p1 (the top-left
 			point).
 
@@ -328,7 +334,7 @@ class RectangleBoundary(Boundary):
 	def _init_boundary(self, p1, p2):
 
 		if not all([valid_coords(p1), valid_coords(p2)]):
-			raise ValueError("'p1' and 'p2' must both be valid (x,y) coordinates.")
+			raise ValueError("'p1' and 'p2' must both be valid (x, y) coordinates.")
 
 		if p1[0] >= p2[0] or p1[1] >= p2[1]:
 			raise ValueError("'p1' must be above and to the left of 'p2'.")
@@ -339,24 +345,24 @@ class RectangleBoundary(Boundary):
 
 	@property
 	def p1(self):
-		""":obj:`Tuple`: The (x,y) coordinates of the top-left corner of the rectangle.
+		""":obj:`Tuple`: The (x, y) coordinates of the top-left corner of the rectangle.
 
 		"""
 		return self.__p1
 
 	@property
 	def p2(self):
-		""":obj:`Tuple`: The (x,y) coordinates of the bottom-right corner of the rectangle.
+		""":obj:`Tuple`: The (x, y) coordinates of the bottom-right corner of the rectangle.
 
 		"""
 		return self.__p2
 
 	@property
 	def center(self):
-		""":obj:`Tuple`: The (x,y) coordinates of the center of the rectangle.
+		""":obj:`Tuple`: The (x, y) coordinates of the center of the rectangle.
 
 		Raises:
-			ValueError: If the given value is not a valid pair of (x,y) coordinates.
+			ValueError: If the given value is not a valid pair of (x, y) coordinates.
 
 		"""
 		return self.__center
@@ -364,7 +370,7 @@ class RectangleBoundary(Boundary):
 	@center.setter
 	def center(self, coords):
 		if not valid_coords(coords):
-			raise ValueError("Boundary center must be a valid set of (x,y) coordinates.")
+			raise ValueError("Boundary center must be a valid set of (x, y) coordinates.")
 		dx = coords[0] - self.__center[0]
 		dy = coords[1] - self.__center[1]
 		self.__p1 = (self.p1[0] + dx, self.p1[1] + dy)
@@ -375,18 +381,18 @@ class RectangleBoundary(Boundary):
 		"""Determines whether a given point is within the boundary.
 
 		Args:
-			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to check for the
-				presence of within the boundary.
+			p (:obj:`Tuple` or :obj:`List`): The (x, y) coordinates of the point to
+				check against the boundary.
 		
 		Returns:
 			bool: True if the point falls within the boundary, otherwise False.
 		
 		Raises:
-			ValueError: If the given point is not a valid set of (x,y) coordinates.
+			ValueError: If the given point is not a valid set of (x, y) coordinates.
 		
 		"""
 		if not valid_coords(p):
-			raise ValueError("The given value must be a valid set of (x,y) coordinates.")
+			raise ValueError("The given value must be a valid set of (x, y) coordinates.")
 			
 		return (self.__p1[0] <= p[0] <= self.__p2[0]) and (self.__p1[1] <= p[1] <= self.__p2[1])
 
@@ -398,11 +404,11 @@ class CircleBoundary(Boundary):
 	
 	Args:
 		label (:obj:`str`): An informative label to use for the boundary.
-		center (:obj:`Tuple`): The (x,y) coordinates of the center of the circle.
+		center (:obj:`Tuple`): The (x, y) coordinates of the center of the circle.
 		radius (int or float): The radius of the circle.
 
 	Raises:
-		ValueError: If 'center' is not a valid pair of (x,y) coordinates.
+		ValueError: If 'center' is not a valid pair of (x, y) coordinates.
 		ValueError: If the given radius is not a number greater than zero.
 
 	"""
@@ -422,10 +428,10 @@ class CircleBoundary(Boundary):
 
 	@property
 	def center(self):
-		""":obj:`Tuple`: The (x,y) coordinates of the center of the circle.
+		""":obj:`Tuple`: The (x, y) coordinates of the center of the circle.
 		
 		Raises:
-			ValueError: If the given value is not a valid pair of (x,y) coordinates.
+			ValueError: If the given value is not a valid pair of (x, y) coordinates.
 
 		"""
 		return self.__center
@@ -433,7 +439,7 @@ class CircleBoundary(Boundary):
 	@center.setter
 	def center(self, coords):
 		if not valid_coords(coords):
-			raise ValueError("The center must be a valid set of (x,y) coordinates.")
+			raise ValueError("The center must be a valid set of (x, y) coordinates.")
 		self.__center = tuple(coords)
 
 	@property
@@ -456,18 +462,18 @@ class CircleBoundary(Boundary):
 		"""Determines whether a given point is within the boundary.
 
 		Args:
-			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to check for the
-				presence of within the boundary.
+			p (:obj:`Tuple` or :obj:`List`): The (x, y) coordinates of the point to
+				check against the boundary.
 		
 		Returns:
 			bool: True if the point falls within the boundary, otherwise False.
 		
 		Raises:
-			ValueError: If the given point is not a valid set of (x,y) coordinates.
+			ValueError: If the given point is not a valid set of (x, y) coordinates.
 		
 		"""
 		if not valid_coords(p):
-			raise ValueError("The given value must be a valid set of (x,y) coordinates.")
+			raise ValueError("The given value must be a valid set of (x, y) coordinates.")
 
 		return line_segment_len(p, self.center) <= self.radius
 
@@ -479,12 +485,12 @@ class AnnulusBoundary(Boundary):
 	
 	Args:
 		label (:obj:`str`): An informative label to use for the boundary.
-		center (:obj:`Tuple`): The (x,y) coordinates of the center of the annulus.
+		center (:obj:`Tuple`): The (x, y) coordinates of the center of the annulus.
 		radius (int or float): The outer radius of the annulus.
 		thickness (int or float): The thickness of the annulus.
 
 	Raises:
-		ValueError: If 'center' is not a valid pair of (x,y) coordinates.
+		ValueError: If 'center' is not a valid pair of (x, y) coordinates.
 		ValueError: If the given radius and thickness are not numbers greater than zero,
 			or if the thickness is equal to or greater than the radius in size.
 
@@ -516,10 +522,10 @@ class AnnulusBoundary(Boundary):
 
 	@property
 	def center(self):
-		""":obj:`Tuple`: The (x,y) coordinates of the center of the annulus.
+		""":obj:`Tuple`: The (x, y) coordinates of the center of the annulus.
 
 		Raises:
-			ValueError: If the given value is not a valid pair of (x,y) coordinates.
+			ValueError: If the given value is not a valid pair of (x, y) coordinates.
 
 		"""
 		return self.__center
@@ -527,7 +533,7 @@ class AnnulusBoundary(Boundary):
 	@center.setter
 	def center(self, coords):
 		if not valid_coords(coords):
-			raise ValueError("The center must be a valid set of (x,y) coordinates.")
+			raise ValueError("The center must be a valid set of (x, y) coordinates.")
 		self.__center = tuple(coords)
 
 	@property
@@ -555,17 +561,17 @@ class AnnulusBoundary(Boundary):
 		"""Determines whether a given point is within the boundary.
 
 		Args:
-			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to check for the
-				presence of within the boundary.
+			p (:obj:`Tuple` or :obj:`List`): The (x, y) coordinates of the point to
+				check against the boundary.
 		
 		Returns:
 			bool: True if the point falls within the boundary, otherwise False.
 		
 		Raises:
-			ValueError: If the given point is not a valid set of (x,y) coordinates.
+			ValueError: If the given point is not a valid set of (x, y) coordinates.
 		
 		"""
 		if not valid_coords(p):
-			raise ValueError("The given value must be a valid set of (x,y) coordinates.")
+			raise ValueError("The given value must be a valid set of (x, y) coordinates.")
 
 		return self.inner_radius <= line_segment_len(p, self.center) <= self.outer_radius

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -21,9 +21,15 @@ your own custom boundary shapes by subclassing the :class:`Boundary` object.
 class BoundaryInspector(object):
 	"""A class for managing and inspecting multiple :class:`Boundary` objects.
 
+	Args:
+		boundaries (:obj:`List`, optional): A list of :obj:`Boundary` objects with which
+			to initialize the inspector.
+
 	"""
-	def __init__(self):
+
+	def __init__(self, boundaries=[]):
 		self.boundaries = OrderedDict()
+		self.add_boundaries(boundaries)
 
 	def __verify_label(self, label):
 		if label not in self.boundaries.keys():

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -214,6 +214,13 @@ class BoundaryInspector(object):
 		"""
 		raise NotImplementedError("Boundary drawing will be implemented in a future version.")
 
+	@property
+	def labels(self):
+		""":obj:`List`: The names of all boundaries currently within the inspector.
+
+		"""
+		return list(self.boundaries.keys())
+	
 
 
 class Boundary(object):

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -25,31 +25,41 @@ class BoundaryInspector(object):
 	def __init__(self):
 		self.boundaries = OrderedDict()
 
-	def add_boundary(self, label, bounds=None, shape=None):
-		"""Adds a boundary to the inspector. Boundaries can either be :class:`Boundary` objects 
-		(e.g. a :class:`RectangleBoundary`), or specified using the label, bounds, and shape
-		arguments.
+	def add_boundary(self, boundary, bounds=None, shape=None):
+		"""Adds a boundary to the inspector.
+		
+		For legacy purposes, boundaries can be added using the label, bounds, and shape
+		arguments. Support for this is deprecated, and may be removed in a future version:
+
+		=============== ========================== ===========================
+		Boundary Type   Shape                      Bounds
+		=============== ========================== ===========================
+		Rectangle       ``klibs.RECT_BOUNDARY``    [(x1, y1), (x2, y2)]
+		--------------- -------------------------- ---------------------------
+		Circle          ``klibs.CIRCLE_BOUNDARY``  [(x, y), radius]
+		--------------- -------------------------- ---------------------------
+		Annulus         ``klibs.ANNULUS_BOUNDARY`` [(x, y), radius, thickness]
+		=============== ========================== ===========================
 
 		Args:
-			label (:class:`Boundary` or :obj:`str`): A valid :class:`Boundary` object if passing
-				an existing boundary, otherwise an informative label to use for the boundary.
-			bounds (:obj:`List`, optional): A List specifying the boundary for the given boundary
-				shape (see the documentation for the 'bounds' attribute for the boundary shape you
-				are creating). Not required if passing an existing :class:`Boundary` object.
-			shape (:obj:`str`): The shape of the new boundary. Can be 'Rectangle',
-				'Circle', or 'Annulus' (case-insensitive). Not required if passing an existing 
-				:class:`Boundary` object.
+			boundary (:obj:`Boundary` or :obj:`str`): A :class:`Boundary` object to add to the
+				inspector. May also be a label string if adding a boundary using the legacy method.
+			bounds (:obj:`List`, optional): A List specifying the size and location of the new
+				boundary (see the 'Bounds' column in the above table). For legacy use only.
+			shape (:obj:`str`, optional): The type of the new boundary (see the 'Shape' column in
+				the above table). For legacy use only.
 
 		Raises:
-			ValueError: If 'bounds' or 'shape' are not provided and 'label' is not a
+			ValueError: If 'bounds' or 'shape' are not provided and 'boundary' is not a
 				:class:`Boundary` object.
 			ValueError: If 'shape' is not one of 'Rectangle', 'Circle', or 'Annulus'.
 		
 		"""
-		if isinstance(label, Boundary): # allow direct adding of boundary objects
-			b = label
+		if isinstance(boundary, Boundary):
+			b = boundary
 			label = b.label
 		else:
+			label = boundary
 			if bounds == None or type(shape) != str:
 				e = "'bounds' and 'shape' must be given if not adding an existing Boundary object."
 				raise ValueError(e)	
@@ -177,7 +187,7 @@ class BoundaryInspector(object):
 		
 		"""
 		raise NotImplementedError("Boundary drawing will be implemented in a future version.")
-	
+
 	def disable_boundaries(self, labels):
 		"""Disables one or more boundaries. If a boundary is disabled, it will not be inspected
 		when calling :meth:~`within_boundaries` and will raise an exception if it is inspected by
@@ -210,6 +220,7 @@ class BoundaryInspector(object):
 			if self.boundaries[label].active:
 				active.append(label)
 		return active
+
 
 
 class Boundary(object):

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -228,7 +228,6 @@ class Boundary(object):
 	"""
 
 	__name__ = "KLBoundary"
-	__shape__ = None
 
 	def __init__(self, label):
 		super(Boundary, self).__init__()
@@ -245,10 +244,6 @@ class Boundary(object):
 	@property
 	def label(self):
 		return self.__label
-
-	@property
-	def shape(self):
-		return self.__shape__
 
 	@property
 	def bounds(self):
@@ -275,7 +270,6 @@ class RectangleBoundary(Boundary):
 
 	"""
 	__name__ = "RectangleBoundary"
-	__shape__ = RECT_BOUNDARY
 
 	def __init__(self, label, p1, p2):
 		super(RectangleBoundary, self).__init__(label)
@@ -371,7 +365,6 @@ class CircleBoundary(Boundary):
 
 	"""
 	__name__ = "CircleBoundary"
-	__shape__ = CIRCLE_BOUNDARY
 
 	def __init__(self, label, center, radius):
 		super(CircleBoundary, self).__init__(label)
@@ -472,7 +465,6 @@ class AnnulusBoundary(Boundary):
 
 	"""
 	__name__ = "AnnulusBoundary"
-	__shape__ = ANNULUS_BOUNDARY
 
 	def __init__(self, label, center, radius, thickness):
 		super(AnnulusBoundary, self).__init__(label)

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -224,10 +224,20 @@ class BoundaryInspector(object):
 
 
 class Boundary(object):
-	"""A base class defining the required attributes and functions of a Boundary object. You will
-	only need to use this class if you want to create your own custom Boundary type. Otherwise, you
-	can use the existing :class:`RectangleBoundary`, :class:`CircleBoundary`, and
-	:class:`AnnulusBoundary` classes instead.
+	"""An abstract base class defining the required properties of a boundary.
+	
+	You will only need to use this class if you want to create your own custom Boundary
+	type. To do this, you will need to subclass this class and override its `within`
+	and `center` methods. This will define the functions that check whether a point is
+	within the custom boundary and update the location of the boundary's center,
+	respectively.
+
+	In addition to the `within` method, you can also check if a point is within a
+	boundary using Python's ``in`` operator::
+
+		boundary = CircleBoundary('start_button', center=(100, 100), radius=50)
+		if mouse_pos() in boundary:
+			print("mouse over start button")
 
 	Args:
 		label (:obj:`str`): An informative label to use for the boundary.
@@ -237,28 +247,25 @@ class Boundary(object):
 	def __init__(self, label):
 		super(Boundary, self).__init__()
 		self.__label = label
+		self.__center = (0, 0)
 
 	def __repr__(self):
 		s = "<klibs.KLBoundary.{0} at {1}>"
-		return s.format(self.__str__, hex(id(self)))
+		return s.format(self, hex(id(self)))
 
 	def __str__(self):
 		return "Boundary()"
-
+		
 	def __contains__(self, p):
  		return self.within(p)
 
 	@property
 	def label(self):
+		""":obj:`str`: The label of the boundary (e.g. 'start_button', 'left_target').
+
+		"""
 		return self.__label
 
-	@property
-	def bounds(self):
-		raise NotImplementedError
-
-	@bounds.setter
-	def bounds(self, boundary):
-		raise NotImplementedError
 
 	@property
 	def center(self):
@@ -276,7 +283,20 @@ class Boundary(object):
 
 	@abc.abstractmethod
 	def within(self, p):
-		pass
+		"""Determines whether a given point is within the boundary.
+
+		Args:
+			p (:obj:`Tuple` or :obj:`List`): The (x,y) coordinates of the point to
+				check against the boundary.
+		
+		Returns:
+			bool: True if the point falls within the boundary, otherwise False.
+		
+		Raises:
+			ValueError: If the given point is not a valid set of (x,y) coordinates.
+		
+		"""
+		raise NotImplementedError
 
 
 

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -231,19 +231,12 @@ class Boundary(object):
 
 	Args:
 		label (:obj:`str`): An informative label to use for the boundary.
-	
-	Attributes:
-		active (bool): Indicates whether the boundary is currently active (used by
-			:class:`BoundaryInspector` objects).
 
 	"""
-
-	__name__ = "KLBoundary"
 
 	def __init__(self, label):
 		super(Boundary, self).__init__()
 		self.__label = label
-		self.active = True
 
 	def __repr__(self):
 		s = "<klibs.KLBoundary.{0} at {1}>"
@@ -251,6 +244,9 @@ class Boundary(object):
 
 	def __str__(self):
 		return "Boundary()"
+
+	def __contains__(self, p):
+ 		return self.within(p)
 
 	@property
 	def label(self):

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -5,7 +5,8 @@ from collections import OrderedDict
 
 from klibs.KLConstants import RECT_BOUNDARY, CIRCLE_BOUNDARY, ANNULUS_BOUNDARY
 from klibs.KLExceptions import BoundaryError
-from klibs.KLUtilities import iterable, midpoint, line_segment_len, valid_coords
+from klibs.KLInternal import valid_coords, iterable
+from klibs.KLUtilities import midpoint, line_segment_len
 
 """A module containing different types of boundaries that can you can use to see if a given point
 is within a given region or not. These boundaries can be used as individual objects, or
@@ -234,6 +235,13 @@ class Boundary(object):
 		self.__label = label
 		self.active = True
 
+	def __repr__(self):
+		s = "<klibs.KLBoundary.{0} at {1}>"
+		return s.format(self.__str__, hex(id(self)))
+
+	def __str__(self):
+		return "Boundary()"
+
 	@property
 	def label(self):
 		return self.__label
@@ -255,6 +263,7 @@ class Boundary(object):
 		pass
 
 
+
 class RectangleBoundary(Boundary):
 	"""A rectangular :obj:`Boundary` object. Can be used to determine whether a point is within a
 	given rectangular region on a surface (e.g. the screen).
@@ -274,6 +283,9 @@ class RectangleBoundary(Boundary):
 		self.__p2 = None
 		self.bounds = [p1, p2]
 		self.__center = midpoint(*self.bounds)
+
+	def __str__(self):
+		return "RectangleBoundary(p1={0}, p2={1})".format(str(self.p1), str(self.p2))
 
 	@property
 	def bounds(self):
@@ -298,13 +310,13 @@ class RectangleBoundary(Boundary):
 			raise ValueError("Rectangle boundaries must be given in the format [p1, p2].")
 
 		if not all([valid_coords(p) for p in boundary]):
-			raise ValueError("'p1' and 'p2' must both be valid sets of (x,y) coordinates.")
+			raise ValueError("'p1' and 'p2' must both be valid (x,y) coordinates.")
 
 		if x1 >= x2 or y1 >= y2:
 			raise ValueError("'p1' must be above and to the left of 'p2'.")
 
-		self.__p1 = boundary[0]
-		self.__p2 = boundary[1]
+		self.__p1 = tuple(boundary[0])
+		self.__p2 = tuple(boundary[1])
 
 	@property
 	def p1(self):
@@ -347,6 +359,7 @@ class RectangleBoundary(Boundary):
 		return (self.__p1[0] <= p[0] <= self.__p2[0]) and (self.__p1[1] <= p[1] <= self.__p2[1])
 
 
+
 class CircleBoundary(Boundary):
 	"""A circle :obj:`Boundary` object. Can be used to determine whether a point is within a
 	given circular region on a surface (e.g. the screen).
@@ -365,6 +378,9 @@ class CircleBoundary(Boundary):
 		self.__c = None
 		self.__r = None
 		self.bounds = [center, radius]
+
+	def __str__(self):
+		return "CircleBoundary(center={0}, radius={1})".format(str(self.center), self.radius)
 
 	@property
 	def bounds(self):
@@ -402,7 +418,7 @@ class CircleBoundary(Boundary):
 	@center.setter
 	def center(self, coords):
 		if valid_coords(coords):
-			self.__c = coords
+			self.__c = tuple(coords)
 		else:
 			raise ValueError("The center must be a valid set of (x,y) coordinates.")
 
@@ -443,6 +459,7 @@ class CircleBoundary(Boundary):
 		return line_segment_len(p, self.__c) <= self.__r
 
 
+
 class AnnulusBoundary(Boundary):
 	"""An annulus :obj:`Boundary` object. Can be used to determine whether a point is within a
 	ring-shaped region on a surface (e.g. the screen).
@@ -463,6 +480,10 @@ class AnnulusBoundary(Boundary):
 		self.__r_outer = None
 		self.__thickness = None
 		self.bounds = [center, radius, thickness]
+
+	def __str__(self):
+		s = "AnnulusBoundary(center={0}, radius={1}, thickness={2})"
+		return s.format(str(self.center), self.outer_radius, self.thickness)
 
 	@property
 	def bounds(self):
@@ -496,7 +517,7 @@ class AnnulusBoundary(Boundary):
 		if thickness >= radius:
 			raise ValueError("The boundary thickness must be smaller than its radius.")
 
-		self.__center = center
+		self.__center = tuple(center)
 		self.__r_outer = radius
 		self.__thickness = thickness
 

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -198,7 +198,9 @@ class BoundaryInspector(object):
 		preserved = OrderedDict()
 		for label in preserve:
 			self.__verify_label(label)
-			preserved[label] = self.boundaries[label]
+		for label in self.labels:
+			if label in preserve:
+				preserved[label] = self.boundaries[label]
 		self.boundaries = preserved
 
 	def draw_boundaries(self, labels=None):
@@ -271,7 +273,6 @@ class Boundary(object):
 
 		"""
 		return self.__label
-
 
 	@property
 	def center(self):

--- a/klibs/KLExceptions.py
+++ b/klibs/KLExceptions.py
@@ -40,7 +40,7 @@ class EyeTrackerError(Exception):
 
 class BoundaryError(Exception):
 	"""Raised when a problem relating to the use of :obj:`~klibs.KLBoundary.Boundary` objects
-	within a :obj:`~klibs.KLBoundary.BoundaryInspector` is encountered.
+	within a :obj:`~klibs.KLBoundary.BoundarySet` is encountered.
 
 	"""
 	def __init__(self, msg):

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -601,8 +601,8 @@ class CursorResponse(ResponseListener, BoundaryInspector):
 		"""See :meth:`ResponseListener.init`.
 
 		"""
-		if len(self.active_boundaries) == 0:
-			e = "The ClickResponse listener must contain at least one active boundary to be used."
+		if len(self.boundaries) == 0:
+			e = "The ClickResponse listener must contain at least one boundary to check."
 			raise BoundaryError(e)
 		show_mouse_cursor()
 

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -16,7 +16,7 @@ from klibs.KLKeyMap import KeyMap
 from klibs.KLUtilities import (pump, flush, hide_mouse_cursor, show_mouse_cursor, mouse_pos,
 	full_trace, iterable, angle_between)
 from klibs.KLUserInterface import ui_request
-from klibs.KLBoundary import BoundaryInspector, AnnulusBoundary
+from klibs.KLBoundary import BoundarySet, AnnulusBoundary
 from klibs.KLGraphics import flip
 from klibs.KLGraphics.utils import aggdraw_to_array
 from klibs.KLGraphics.KLDraw import Annulus, ColorWheel, Drawbject
@@ -565,10 +565,11 @@ class MouseButtonResponse(ResponseListener):
 			raise ValueError('Property on_release must be either True or False.')
 
 
-class CursorResponse(ResponseListener, BoundaryInspector):
-	"""A response listener that listens for mouse clicks within one or more boundaries on the
-	screen. See the documentation for the :class:`BoundaryInspector` class for information on
-	how to add, enable, disable, and remove boundaries from this listener.
+class CursorResponse(ResponseListener, BoundarySet):
+	"""Listens for mouse clicks within one or more boundaries on the screen.
+	
+	See the documentation for the :class:`BoundarySet` class for information on how to
+	add and remove boundaries from this listener.
 
 	**ResponseCollector attribute:** 
 	
@@ -593,7 +594,7 @@ class CursorResponse(ResponseListener, BoundaryInspector):
 
 	def __init__(self):
 		super(CursorResponse, self).__init__('cursor_listener')
-		BoundaryInspector.__init__(self)
+		BoundarySet.__init__(self)
 		self.__event_type = SDL_MOUSEBUTTONDOWN
 		self.return_coords = False
 
@@ -845,7 +846,7 @@ class ColorWheelResponse(ResponseListener):
 		self.__wheel.rotation = angle
 
 
-class DrawResponse(ResponseListener, BoundaryInspector):
+class DrawResponse(ResponseListener, BoundarySet):
 	"""A response listener that collects (and optionally renders) a drawing made by the cursor
 	on screen.
 	
@@ -868,7 +869,7 @@ class DrawResponse(ResponseListener, BoundaryInspector):
 
 	def __init__(self):
 		super(DrawResponse, self).__init__(RC_DRAW)
-		BoundaryInspector.__init__(self)
+		BoundarySet.__init__(self)
 		# Internal use variables
 		self.points = []
 		self.started = False

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -31,9 +31,18 @@ def test_rectangle_boundary():
     assert (10, 10) in rect
     assert not (0, 0) in rect
 
+    # Test boundary movement
+    rect.center = (50, 60)
+    assert rect.p1 == (30, 40)
+    assert rect.p2 == (70, 80)
+    assert rect.within((10, 10)) == False
+    assert rect.within((70, 80)) == True
+
     # Test boundary exceptions
     with pytest.raises(ValueError):
         rect.within(5)
+    with pytest.raises(ValueError):
+        rect.center = (0, 0, 0)
     with pytest.raises(ValueError):
         klb.RectangleBoundary('test4', p1=(60, 60), p2=(50, 50))
     with pytest.raises(ValueError):
@@ -66,9 +75,17 @@ def test_circle_boundary():
     assert (50, 100) in circle
     assert not (0, 0) in circle
 
+    # Test boundary movement
+    circle.center = (50, 50)
+    assert circle.center == (50, 50)
+    assert circle.within((100, 150)) == False
+    assert circle.within((50, 1)) == True
+
     # Test boundary exceptions
     with pytest.raises(ValueError):
         circle.within(5)
+    with pytest.raises(ValueError):
+        circle.center = (0, 0, 0)
     with pytest.raises(ValueError):
         klb.CircleBoundary('test4', center=(100, 100), radius=-4)
     with pytest.raises(ValueError):
@@ -107,9 +124,17 @@ def test_annulus_boundary():
     assert (55, 100) in ring
     assert not (0, 0) in ring
 
+    # Test boundary movement
+    ring.center = (50, 50)
+    assert ring.center == (50, 50)
+    assert ring.within((100, 150)) == False
+    assert ring.within((50, 1)) == True
+
     # Test boundary exceptions
     with pytest.raises(ValueError):
         ring.within(5)
+    with pytest.raises(ValueError):
+        ring.center = (0, 0, 0)
     with pytest.raises(ValueError):
         klb.AnnulusBoundary('test4', center=(100, 100), radius=-4, thickness=10)
     with pytest.raises(ValueError):

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -13,6 +13,9 @@ def test_rectangle_boundary():
     pos = klb.RectangleBoundary('test2', (10, 10), (50, 50))
     floats = klb.RectangleBoundary('test3', p1=(10.4, 10.8), p2=(50.5, 50.2))
 
+    # Test string
+    assert str(rect) == "RectangleBoundary(p1=(10, 10), p2=(50, 50))"
+
     # Test boundary attributes
     assert rect.label == 'test1'
     assert rect.p1 == (10, 10)
@@ -43,6 +46,9 @@ def test_circle_boundary():
     pos = klb.CircleBoundary('test2', (100, 100), 50)
     floats = klb.CircleBoundary('test3', center=(99.5, 100), radius=43.5)
 
+    # Test string
+    assert str(circle) == "CircleBoundary(center=(100, 100), radius=50)"
+
     # Test boundary attributes
     assert circle.label == 'test1'
     assert circle.center == (100, 100)
@@ -72,6 +78,9 @@ def test_annulus_boundary():
     # Test position arguments and boundaries with floats
     pos = klb.AnnulusBoundary('test2', (100, 100), 50, 10)
     floats = klb.AnnulusBoundary('test3', center=(99.5, 100), radius=43.5, thickness=4.6)
+
+    # Test string
+    assert str(ring) == "AnnulusBoundary(center=(100, 100), radius=50, thickness=10)"
 
     # Test boundary attributes
     assert ring.label == 'test1'
@@ -157,6 +166,15 @@ def test_boundary_inspector():
     assert inspector.within_boundary('test1', (20, 40)) == True
     assert inspector.within_boundary('test2', (20, 40)) == False
     assert inspector.within_boundary('test3', (20, 40)) == True
+
+    # Test combined boundary tests
+    inspector = klb.BoundaryInspector()
+    inspector.add_boundaries([tst1, tst2, tst3])
+    assert inspector.which_boundary((20, 40)) == 'test3'
+    assert inspector.which_boundary((20, 40), ignore='test3') == 'test1'
+    assert inspector.which_boundary((20, 40), ignore=['test3']) == 'test1'
+    assert inspector.which_boundary((20, 40), labels=['test1', 'test2']) == 'test1'
+    assert inspector.which_boundary((20, 40), labels=['test2']) == None
 
     # Test exceptions
     inspector = klb.BoundaryInspector()

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -142,8 +142,7 @@ def test_boundary_inspector():
     assert len(inspector.boundaries) == 3
 
     # Test removing boundaries from the inspector
-    inspector = klb.BoundaryInspector()
-    inspector.add_boundaries([tst1, tst2, tst3])
+    inspector = klb.BoundaryInspector([tst1, tst2, tst3])
     assert len(inspector.boundaries) == 3
     inspector.remove_boundaries('test1')
     assert len(inspector.boundaries) == 2

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -157,7 +157,7 @@ def test_boundary_inspector():
     inspector.add_boundaries([tst1, tst2, tst3])
     inspector.clear_boundaries(preserve=['test2'])
     assert len(inspector.boundaries) == 1
-    assert 'test2' in inspector.boundaries.keys()
+    assert 'test2' in inspector.labels
 
     # Test individual boundary tests
     inspector = klb.BoundaryInspector()

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -28,6 +28,8 @@ def test_rectangle_boundary():
     assert rect.within((35.3, 35)) == True
     assert rect.within((10, 10)) == True
     assert rect.within((50, 50)) == True
+    assert (10, 10) in rect
+    assert not (0, 0) in rect
 
     # Test boundary exceptions
     with pytest.raises(ValueError):
@@ -61,6 +63,8 @@ def test_circle_boundary():
     assert circle.within((99.7, 100)) == True
     assert circle.within((50, 100)) == True
     assert circle.within((100, 150)) == True
+    assert (50, 100) in circle
+    assert not (0, 0) in circle
 
     # Test boundary exceptions
     with pytest.raises(ValueError):
@@ -100,6 +104,8 @@ def test_annulus_boundary():
     assert ring.within((60, 100)) == True
     assert ring.within((100, 150)) == True
     assert ring.within((100, 140)) == True
+    assert (55, 100) in ring
+    assert not (0, 0) in ring
 
     # Test boundary exceptions
     with pytest.raises(ValueError):

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -189,6 +189,12 @@ def test_boundary_inspector():
     inspector.clear_boundaries(preserve=['test2'])
     assert len(inspector.boundaries) == 1
     assert 'test2' in inspector.labels
+    
+    # Test that preserved boundaries during clear keep same order
+    inspector.add_boundaries([tst1, tst2, tst3])
+    inspector.clear_boundaries(preserve=['test3', 'test1'])
+    assert len(inspector.boundaries) == 2
+    assert inspector.labels == ['test1', 'test3']
 
     # Test individual boundary tests
     inspector = klb.BoundaryInspector()

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -155,9 +155,9 @@ def test_annulus_boundary():
         klb.AnnulusBoundary('test7', center=100, radius=50, thickness=10)
 
 
-def test_boundary_inspector():
+def test_boundary_set():
 
-    inspector = klb.BoundaryInspector()
+    inspector = klb.BoundarySet()
     tst1 = klb.RectangleBoundary('test1', p1=(10, 10), p2=(50, 50))
     tst2 = klb.RectangleBoundary('test2', p1=(60, 60), p2=(100, 100))
     tst3 = klb.RectangleBoundary('test3', p1=(10, 30), p2=(50, 70))
@@ -176,14 +176,14 @@ def test_boundary_inspector():
     assert len(inspector.boundaries) == 3
 
     # Test current method of adding boundaries to inspector
-    inspector = klb.BoundaryInspector()
+    inspector = klb.BoundarySet()
     inspector.add_boundary(tst1)
     assert len(inspector.boundaries) == 1
     inspector.add_boundaries([tst2, tst3])
     assert len(inspector.boundaries) == 3
 
     # Test removing boundaries from the inspector
-    inspector = klb.BoundaryInspector([tst1, tst2, tst3])
+    inspector = klb.BoundarySet([tst1, tst2, tst3])
     assert len(inspector.boundaries) == 3
     inspector.remove_boundaries('test1')
     assert len(inspector.boundaries) == 2
@@ -191,7 +191,7 @@ def test_boundary_inspector():
     assert len(inspector.boundaries) == 0
 
     # Test clearing boundaries from the inspector
-    inspector = klb.BoundaryInspector()
+    inspector = klb.BoundarySet()
     inspector.add_boundaries([tst1, tst2, tst3])
     inspector.clear_boundaries()
     assert len(inspector.boundaries) == 0
@@ -207,14 +207,14 @@ def test_boundary_inspector():
     assert inspector.labels == ['test1', 'test3']
 
     # Test individual boundary tests
-    inspector = klb.BoundaryInspector()
+    inspector = klb.BoundarySet()
     inspector.add_boundaries([tst1, tst2, tst3])
     assert inspector.within_boundary('test1', (20, 40)) == True
     assert inspector.within_boundary('test2', (20, 40)) == False
     assert inspector.within_boundary('test3', (20, 40)) == True
 
     # Test combined boundary tests
-    inspector = klb.BoundaryInspector()
+    inspector = klb.BoundarySet()
     inspector.add_boundaries([tst1, tst2, tst3])
     assert inspector.which_boundary((20, 40)) == 'test3'
     assert inspector.which_boundary((20, 40), ignore='test3') == 'test1'
@@ -223,7 +223,7 @@ def test_boundary_inspector():
     assert inspector.which_boundary((20, 40), labels=['test2']) == None
 
     # Test exceptions
-    inspector = klb.BoundaryInspector()
+    inspector = klb.BoundarySet()
     with pytest.raises(ValueError):
         inspector.add_boundary('hello')
     with pytest.raises(ValueError):

--- a/klibs/tests/test_KLBoundary.py
+++ b/klibs/tests/test_KLBoundary.py
@@ -21,6 +21,8 @@ def test_rectangle_boundary():
     assert rect.p1 == (10, 10)
     assert rect.p2 == (50, 50)
     assert rect.center == (30, 30)
+    assert rect.width == 40
+    assert rect.height == 40
 
     # Test boundary usage
     assert rect.within((0, 0)) == False
@@ -38,13 +40,21 @@ def test_rectangle_boundary():
     assert rect.within((10, 10)) == False
     assert rect.within((70, 80)) == True
 
+    # Test handling of when p1 > p2
+    swapped = klb.RectangleBoundary('swapped', (50, 50), (10, 10))
+    assert swapped.p1 == (10, 10)
+    assert swapped.p2 == (50, 50)
+    swapped = klb.RectangleBoundary('swapped', (50, 10), (10, 50))
+    assert swapped.p1 == (10, 10)
+    assert swapped.p2 == (50, 50)
+
     # Test boundary exceptions
     with pytest.raises(ValueError):
         rect.within(5)
     with pytest.raises(ValueError):
         rect.center = (0, 0, 0)
     with pytest.raises(ValueError):
-        klb.RectangleBoundary('test4', p1=(60, 60), p2=(50, 50))
+        klb.RectangleBoundary('test4', p1=(60, 60), p2=(60, 50))
     with pytest.raises(ValueError):
         klb.RectangleBoundary('test5', p1=0, p2=(50, 50))
 


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR reworks the KLBoundary module to make it nicer to deal with. In addition to adding support for using the `in` operator with boundaries and allowing all Boundary types to be relocated using their `center` attribute, this PR also simplifies the BoundaryInspector class (and renames it to BoundarySet) and makes it easier to work with.


# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
