### PR TITLE
Clean up CLI interface code

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -43,7 +43,7 @@ New Features:
   :attr:`~klibs.KLGraphics.NumpySurface.surface_c` attributes to the
   NumpySurface class for retrieving the current dimensions and midpoint of a
   surface, respectively.
-* Improved the loading speed of the ``klibs`` command line.
+* Significantly improved the speed of the ``klibs`` command line interface.
 * Added proper print methods for all built-in :obj:`~klibs.KLBoundary.Boundary`
   types.
 * Added a new argument ``ignore`` to the

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -67,6 +67,8 @@ New Features:
 * Replaced an unnecessary runtime warning about PyAudio on launch (regardless of
   whether the project required audio input) with a ``RuntimeError`` if trying to
   collect an :class:`~klibs.KLResponseCollectors.AudioResponse` without PyAudio.
+* Raise an error instead of entering the missing database prompt when trying to
+  export data or rebuild the database for a project without a database file.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -140,3 +140,5 @@ Fixed Bugs:
   a runtime warning.
 * Fixed :meth:`~klibs.KLBoundary.BoundarySet.clear_boundaries` to always
   keep preserved boundaries in the same order as they were added.
+* Fixed suppression of colorized console output on terminals that don't support
+  it.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -69,6 +69,8 @@ New Features:
   collect an :class:`~klibs.KLResponseCollectors.AudioResponse` without PyAudio.
 * Raise an error instead of entering the missing database prompt when trying to
   export data or rebuild the database for a project without a database file.
+* ``klibs update`` now installs the latest GitHub release of KLibs instead of
+  the latest commit from the default branch.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -64,6 +64,9 @@ New Features:
   their ``center`` attribute to a set of pixel coordinates.
 * :obj:`~klibs.KLBoundary.RectangleBoundary` objects now have ``height`` and
   ``width`` attributes.
+* Replaced an unnecessary runtime warning about PyAudio on launch (regardless of
+  whether the project required audio input) with a ``RuntimeError`` if trying to
+  collect an :class:`~klibs.KLResponseCollectors.AudioResponse` without PyAudio.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -71,6 +71,8 @@ New Features:
   export data or rebuild the database for a project without a database file.
 * ``klibs update`` now installs the latest GitHub release of KLibs instead of
   the latest commit from the default branch.
+* ``EDF`` folder is no longer created by default for new projects. It is now
+  created only if needed when saving data from an eye tracking experiment.
 
 
 API Changes:

--- a/klibs/KLAudio.py
+++ b/klibs/KLAudio.py
@@ -52,20 +52,18 @@ class AudioManager(object):
 		if not sdl2.SDL_WasInit(sdl2.SDL_INIT_AUDIO):
 			sdl2.SDL_Init(sdl2.SDL_INIT_AUDIO)
 			sdl2.sdlmixer.Mix_OpenAudio(44100, sdl2.sdlmixer.MIX_DEFAULT_FORMAT, 2, 1024)
+		self.input = None
+		self.stream = None
 		if PYAUDIO_AVAILABLE:
 			try:
 				self.input = pyaudio.PyAudio()
 				self.device_name = self.input.get_default_input_device_info()['name']
 				self.stream = AudioStream(self.input)
 			except IOError:
-				print("Warning: Could not find a valid audio input device, audio input will "
-					"not be available.")
+				print("* Warning: Could not find a valid audio input device, audio input will "
+					"not be available.\n")
 				self.input = None
 				self.stream = None
-		else:
-			print("\t* Warning: PyAudio library not found; audio input will not be available.")
-			self.input = None
-			self.stream = None
 
 	def calibrate(self):
 		"""Determines a threshold loudness to use for vocal responses based on sample input from

--- a/klibs/KLDatabase.py
+++ b/klibs/KLDatabase.py
@@ -501,7 +501,6 @@ class DatabaseManager(EnvAgent):
 		except TypeError:
 			join_tables = []
 
-		cso("\n<green>*** Exporting data from {0} ***</green>\n".format(P.project_name))
 		self.__set_type_conversions(export=True)
 		column_names, data = self.collect_export_data(multi_file, join_tables)
 

--- a/klibs/KLDatabase.py
+++ b/klibs/KLDatabase.py
@@ -1,12 +1,11 @@
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
+import os
 import io
 import shutil
 import sqlite3
 from copy import copy
 from itertools import chain
-from os import remove, rename
-from os.path import join, isfile, basename
 from collections import OrderedDict
 
 from klibs.KLEnvironment import EnvAgent
@@ -14,9 +13,8 @@ from klibs.KLConstants import (DB_CREATE, DB_COL_TITLE, DB_SUPPLY_PATH, SQL_COL_
 	SQL_NUMERIC, SQL_FLOAT, SQL_REAL, SQL_INT, SQL_BOOL, SQL_STR, SQL_BIN, SQL_KEY, SQL_NULL,
 	PY_INT, PY_FLOAT, PY_BOOL, PY_BIN, PY_STR, QUERY_SEL, TAB, ID)
 from klibs import P
-from klibs.KLUtilities import (full_trace, type_str, iterable, bool_to_int, boolean_to_logical,
-	snake_to_camel, utf8)
-from klibs.KLUtilities import colored_stdout as cso
+from klibs.KLInternal import full_trace, iterable, utf8
+from klibs.KLInternal import colored_stdout as cso
 from klibs.KLRuntimeInfo import session_info_schema
 
 
@@ -364,8 +362,8 @@ class DatabaseManager(EnvAgent):
 	
 	def __restore__(self):
 		# restores database file from the back-up of it
-		remove(P.database_path)
-		rename(P.database_backup_path, P.database_path)
+		os.remove(P.database_path)
+		os.rename(P.database_backup_path, P.database_path)
 	
 	
 	def __set_type_conversions(self, export=False):
@@ -602,8 +600,8 @@ class DatabaseManager(EnvAgent):
 			if incomplete: suffix = "_incomplete" + suffix
 			if duplicate_count: suffix = "_{0}".format(duplicate_count) + suffix
 			fname = basename + suffix
-			filepath = join(P.incomplete_data_dir if incomplete else P.data_dir, fname)
-			if isfile(filepath):
+			filepath = os.path.join(P.incomplete_data_dir if incomplete else P.data_dir, fname)
+			if os.path.isfile(filepath):
 				duplicate_count += 1
 			else:
 				break

--- a/klibs/KLExperiment.py
+++ b/klibs/KLExperiment.py
@@ -3,30 +3,14 @@ __author__ = 'Jonathan Mulle & Austin Hurst'
 
 import os
 import sys
-import warnings
 from abc import abstractmethod
 from traceback import print_tb, print_stack
 
-# Suppresses possible pysdl2-dll warning message on import
-with warnings.catch_warnings():	
-	warnings.simplefilter("ignore")
-	import sdl2
-
+from klibs import P
 from klibs.KLEnvironment import EnvAgent
 from klibs.KLExceptions import TrialException
-from klibs import P
-from klibs.KLKeyMap import KeyMap
-from klibs.KLUtilities import full_trace, pump, flush, now, show_mouse_cursor, hide_mouse_cursor
-from klibs.KLUtilities import colored_stdout as cso
-from klibs.KLTrialFactory import TrialFactory
-from klibs.KLGraphics import flip, blit, fill, clear
-from klibs.KLGraphics.KLNumpySurface import NumpySurface as NpS
-from klibs.KLGraphics import KLDraw as kld
-from klibs.KLDatabase import EntryTemplate
-from klibs.KLUserInterface import any_key
-from klibs.KLAudio import AudioManager
-from klibs.KLResponseCollectors import ResponseCollector
-from klibs.KLCommunication import message, query, collect_demographics
+from klibs.KLInternal import full_trace
+from klibs.KLInternal import colored_stdout as cso
 
 
 class Experiment(EnvAgent):
@@ -35,10 +19,15 @@ class Experiment(EnvAgent):
 	paused = False
 
 	def __init__(self):
+		from klibs.KLAudio import AudioManager
+		from klibs.KLResponseCollectors import ResponseCollector
+		from klibs.KLTrialFactory import TrialFactory
+
 		super(Experiment, self).__init__()
 
 		self.incomplete = True # flag for keeping track of session completeness
 		self.blocks = None # blocks of trials for the experiment
+		self.tracker_dot = None # overlay of eye tracker gaze location in devmode
 
 		self.audio = AudioManager() # initialize audio management for the experiment
 		self.rc = ResponseCollector() # add default response collector
@@ -54,6 +43,7 @@ class Experiment(EnvAgent):
 		"""For internal use, actually runs the blocks/trials of the experiment in sequence.
 
 		"""
+		from klibs.KLGraphics import clear
 
 		if self.blocks == None:
 			self.blocks = self.trial_factory.export_trials()
@@ -75,7 +65,7 @@ class Experiment(EnvAgent):
 				except TrialException:
 					block.recycle()
 					P.recycle_count += 1
-					clear()
+					clear() # NOTE: is this actually wanted?
 				self.rc.reset()
 		self.clean_up()
 
@@ -89,7 +79,7 @@ class Experiment(EnvAgent):
 		"""
 		Private method; manages a trial.
 		"""
-		pump()
+		from klibs.KLUtilities import pump, show_mouse_cursor, hide_mouse_cursor
 
 		# At start of every trial, before setup_response_collector or trial_prep are run, retrieve
 		# the values of the independent variables (factors) for that trial (as generated earlier by
@@ -99,6 +89,7 @@ class Experiment(EnvAgent):
 			iv_value = trial[factors.index(iv)]
 			setattr(self, iv, iv_value)
 
+		pump()
 		self.setup_response_collector()
 		self.trial_prep()
 		tx = None
@@ -133,10 +124,13 @@ class Experiment(EnvAgent):
 		"""Internal method, logs trial data to database.
 
 		"""
+		from klibs.KLDatabase import EntryTemplate
+
 		trial_template = EntryTemplate('trials')
 		trial_template.log(P.id_field_name, P.participant_id)
 		for attr in trial_data:
 			trial_template.log(attr, trial_data[attr])
+
 		return self.database.insert(trial_template)
 
 
@@ -262,11 +256,9 @@ class Experiment(EnvAgent):
 		function if desired.
 
 		"""
+		from klibs.KLGraphics import blit
+
 		if P.show_gaze_dot and self.el.recording:
-			try:
-				self.tracker_dot
-			except AttributeError:
-				self.tracker_dot = kld.Ellipse(8, stroke=[2, (255,255,255)], fill=(255,0,0)).render()
 			try:
 				blit(self.tracker_dot, 5, self.el.gaze())
 			except RuntimeError:
@@ -278,6 +270,7 @@ class Experiment(EnvAgent):
 		recording is stopped. This, not Python's sys.exit(), should be used to exit an experiment.
 
 		"""
+		import sdl2
 		if P.verbose_mode:
 			print_tb(print_stack(), 6)
 
@@ -317,9 +310,14 @@ class Experiment(EnvAgent):
 		the actual experiment.
 
 		"""
-
-		if P.eye_tracking and not P.manual_eyelink_setup:
-			self.el.setup()
+		from klibs.KLGraphics.KLDraw import Ellipse
+	
+		if P.eye_tracking:
+			RED = (255, 0, 0)
+			WHITE = (255, 255, 255)
+			self.tracker_dot = Ellipse(8, stroke=[2, WHITE], fill=RED).render()
+			if not P.manual_eyelink_setup:
+				self.el.setup()
 
 		self.setup()
 		try:
@@ -331,6 +329,10 @@ class Experiment(EnvAgent):
 
 
 	def show_logo(self):
+		from klibs.KLUtilities import flush
+		from klibs.KLUserInterface import any_key
+		from klibs.KLGraphics import fill, blit, flip
+		from klibs.KLGraphics import NumpySurface as NpS
 		logo = NpS(P.logo_file_path)
 		flush()
 		for i in (1, 2):

--- a/klibs/KLEyeTracking/KLEyeLink.py
+++ b/klibs/KLEyeTracking/KLEyeLink.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
+import os
 import time
-from os.path import join
 from klibs.KLEyeTracking import PYLINK_AVAILABLE
 
 from klibs.KLExceptions import TrialException, EyeTrackerError
@@ -154,8 +154,11 @@ class EyeLink(BaseEyeLink, EyeTracker):
                 subfolder of the eye tracker data directory ('ExpAssets/EDF'). Defaults to False.
 
 		"""
-		# Determine whether EDF should go to 'incomplete' subfolder or not
+		# Determine destination path for EDF (creating parent folder if needed)
 		edf_dir = P.incomplete_edf_dir if incomplete else P.edf_dir
+		if not os.path.isdir(edf_dir):
+			os.makedirs(edf_dir)
+		edf_path = os.path.join(edf_dir, self.edf_filename)
 
 		self._quitting = True
 		if self.isRecording() == 0:
@@ -164,7 +167,7 @@ class EyeLink(BaseEyeLink, EyeTracker):
 		self.setOfflineMode()
 		msecDelay(500)
 		self.closeDataFile()
-		self.receiveDataFile(self.edf_filename, join(edf_dir, self.edf_filename))
+		self.receiveDataFile(self.edf_filename, edf_path)
 		return self.close()
 
 

--- a/klibs/KLEyeTracking/KLEyeLink.py
+++ b/klibs/KLEyeTracking/KLEyeLink.py
@@ -13,20 +13,22 @@ from klibs.KLConstants import (EL_LEFT_EYE, EL_RIGHT_EYE, EL_BOTH_EYES, EL_NO_EY
 	EL_ALL_EVENTS, EL_TRUE, EL_FALSE,
 	TK_S, TK_MS, CIRCLE_BOUNDARY, RECT_BOUNDARY)
 from klibs import P
-from klibs.KLUtilities import full_trace, iterable, hide_mouse_cursor, mouse_pos, now
-from klibs.KLUtilities import colored_stdout as cso
+from klibs.KLInternal import full_trace, valid_coords, now, hide_stderr
+from klibs.KLInternal import colored_stdout as cso
 from klibs.KLUserInterface import ui_request
+from klibs.KLUtilities import hide_mouse_cursor
 from klibs.KLGraphics import blit, fill, flip, clear
 from klibs.KLGraphics.KLDraw import drift_correct_target
 from klibs.KLEyeTracking.KLEyeTracker import EyeTracker
 
 if PYLINK_AVAILABLE:
-	from pylink import (openGraphicsEx, flushGetkeyQueue, pumpDelay,
-		beginRealTimeMode, endRealTimeMode, msecDelay)
-	from pylink import EyeLink as BaseEyeLink
+	with hide_stderr(macos_only=True):
+		from pylink import (
+			openGraphicsEx, beginRealTimeMode, endRealTimeMode, flushGetkeyQueue,
+			pumpDelay, msecDelay
+		)
+		from pylink import EyeLink as BaseEyeLink
 	from .KLCustomEyeLinkDisplay import ELCustomDisplay
-	cso("<green_d>(Note: if a bunch of SDL errors were just reported, this was expected, "
-		"do not be alarmed!)</green_d>")
 
 class EyeLink(BaseEyeLink, EyeTracker):
 	"""A connection to an SR Research EyeLink eye tracker, providing a friendly interface to the
@@ -263,7 +265,7 @@ class EyeLink(BaseEyeLink, EyeTracker):
 		target = drift_correct_target() if target is None else target
 		draw_target = EL_TRUE if draw_target in [EL_TRUE, True] else EL_FALSE
 		location = P.screen_c if location is None else location
-		if not iterable(location):
+		if not valid_coords(location):
 			raise ValueError("'location' must be a pair of (x,y) pixel coordinates.")
 
 		try:

--- a/klibs/KLInternal.py
+++ b/klibs/KLInternal.py
@@ -9,6 +9,7 @@ import binascii
 import traceback
 from sys import exc_info
 from datetime import datetime
+from contextlib import contextmanager
 
 from klibs.KLConstants import DATETIME_STAMP
 from klibs import P
@@ -255,6 +256,31 @@ def log(msg, priority):
 	if priority <= P.verbosity:
 		with open(P.log_file_path, 'a') as log_file:
 			log_file.write(str(priority) + ": " + msg)
+
+
+@contextmanager
+def hide_stderr(macos_only=False):
+	"""Temporarily suppresses stderr output.
+	
+	Useful for hiding useless noise from C libraries that can't be hidden through
+	the usual Python ways.
+
+	Args:
+		macos_only (bool, optional): If True, stderr will only be suppressed on macOS.
+			Defaults to False.
+
+	"""
+	# NOTE: Check if this works on Windows
+	if macos_only == False or sys.platform == "darwin":
+		devnull = os.open(os.devnull, os.O_WRONLY)
+		old_stderr = os.dup(2)
+		os.dup2(devnull, 2)
+		yield
+		os.dup2(old_stderr, 2)
+		os.close(devnull)
+		os.close(old_stderr)
+	else:
+		yield
 
 
 def full_trace():

--- a/klibs/KLInternal.py
+++ b/klibs/KLInternal.py
@@ -212,9 +212,9 @@ def colored_stdout(string, print_string=True):
 	out = ""
 	stack = []
 	for s in re.split(code_pattern, string):
-		if re.match(code_pattern, s) and P.color_output:
+		if re.match(code_pattern, s):
 			code = re.findall(r"</?([a-z_]+)>", s)[0]
-			if not code in codes.keys():
+			if not (code in codes.keys() and P.color_output):
 				continue
 			if s[:2] == "</":
 				if code == "bold" and "bold" in stack:

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -20,6 +20,7 @@ from klibs.KLBoundary import BoundarySet, AnnulusBoundary
 from klibs.KLGraphics import flip
 from klibs.KLGraphics.utils import aggdraw_to_array
 from klibs.KLGraphics.KLDraw import Annulus, ColorWheel, Drawbject
+from klibs.KLAudio import PYAUDIO_AVAILABLE
 
 
 
@@ -386,6 +387,10 @@ class AudioResponse(ResponseListener):
 		super(AudioResponse, self).__init__(RC_AUDIO)
 		self.__threshold = None
 		self._stream_error = False
+		if not PYAUDIO_AVAILABLE:
+			e = ("The 'pyaudio' package must be installed in order to use the "
+				"AudioResponse listener.")
+			raise RuntimeError(e)
 
 	def init(self):
 		"""See :meth:`ResponseListener.init`.

--- a/klibs/KLUtilities.py
+++ b/klibs/KLUtilities.py
@@ -145,15 +145,6 @@ def flush():
 	SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT)
 
 
-def getinput(*args, **kwargs):
-	# python-agnostic function for getting console input. Saves us from requring 'future'
-	# or 'six' compatibility package (for now, anyway).
-	try:
-		return raw_input(*args, **kwargs)
-	except NameError:
-		return input(*args, **kwargs)
-
-
 def hide_mouse_cursor():
 	"""Hides the mouse cursor if it is currently shown. Otherwise, this function does nothing.
 	

--- a/klibs/__main__.py
+++ b/klibs/__main__.py
@@ -174,6 +174,7 @@ def cli():
 	for key in args:
 		if key != "func": arg_dict[key] = args[key]
 
+	print("") # Add a blank line before any CLI output
 	args["func"](**arg_dict)
 
 

--- a/klibs/__main__.py
+++ b/klibs/__main__.py
@@ -8,7 +8,7 @@ import binascii
 
 try:
 	from klibs import P
-	from klibs.cli import create, run, export, rebuild_db, hard_reset, update
+	from klibs import cli
 except:
 	print("\n\033[91m*** Fatal Error: Unable to load KLibs ***\033[0m\n\nStack Trace:")
 	exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -19,7 +19,7 @@ except:
 
 # The function that gets run when klibs is launched from the command line
 
-def cli(): 
+def klibs_main():
 
 	sys.dont_write_bytecode = True # suppress creation of useless .pyc files
 
@@ -62,7 +62,8 @@ def cli():
         epilog="For help on how to use a specific command, try 'klibs (command) --help'."
 	)
 	subparsers = parser.add_subparsers(
-		title='commands', metavar='                                    ' # fixes indentation issue
+		dest='command', title='commands',
+		metavar='                                    ' # fixes indentation issue
 	)
 
 	create_parser = subparsers.add_parser('create', 
@@ -78,7 +79,6 @@ def cli():
 		help=("The path where the new project should be created. "
 		"Defaults to current working directory.")
 	)
-	create_parser.set_defaults(func=create)
 
 	run_parser = subparsers.add_parser('run', formatter_class=CustomHelpFormatter,
 		help='Run a KLibs experiment',
@@ -113,7 +113,6 @@ def cli():
 	#run_parser.add_argument('-v', '--verbose', action="store_true",
 	#	help="Logs extra klibs debug information to the terminal."
 	#)
-	run_parser.set_defaults(func=run)
 
 	export_parser = subparsers.add_parser('export', formatter_class=CustomHelpFormatter,
 		help='Export data to ExpAssets/Data/',
@@ -135,7 +134,6 @@ def cli():
 		help=("Additional tables to be joined to the data output. "
 		"Only 'participant' and 'data' tables are joined by default.")
 	)
-	export_parser.set_defaults(func=export)
 
 	update_parser = subparsers.add_parser('update', formatter_class=CustomHelpFormatter,
 		help='Update KLibs to the latest available version',
@@ -145,7 +143,6 @@ def cli():
 		help=("The branch of the a-hurst/klibs repository from which to update KLibs. "
 		"Installs the latest stable release if not specified.")
 	)
-	update_parser.set_defaults(func=update)
 
 	rebuild_parser = subparsers.add_parser('db-rebuild',
 		help='Delete and rebuild the database',
@@ -155,7 +152,6 @@ def cli():
 		help=("Path to the directory containing the KLibs project. "
 		"Defaults to current working directory.")
 	)
-	rebuild_parser.set_defaults(func=rebuild_db)
 
 	reset_parser = subparsers.add_parser('hard-reset',
 		help='Delete all collected data',
@@ -165,19 +161,27 @@ def cli():
 		help=("Path to the directory containing the KLibs project. "
 		"Defaults to current working directory.")
 	)
-	reset_parser.set_defaults(func=hard_reset)
 
+	# Load the provided command and arguments, printing usage info if none given
 	args = vars(parser.parse_args())
+	cmd = args.pop("command", None)
+	if not cmd:
+		parser.print_usage()
+		return
 
-
-	arg_dict = {}
-	for key in args:
-		if key != "func": arg_dict[key] = args[key]
-
+	# Actually run the requested command
+	commands = {
+		"create": cli.create,
+		"run": cli.run,
+		"export": cli.export,
+		"db-rebuild": cli.rebuild_db,
+		"hard-reset": cli.hard_reset,
+		"update": cli.update,
+	}
 	print("") # Add a blank line before any CLI output
-	args["func"](**arg_dict)
+	commands[cmd](**args)
 	print("") # Add a blank line after any CLI output
 
 
 if __name__ == '__main__':
-	cli()
+	klibs_main()

--- a/klibs/__main__.py
+++ b/klibs/__main__.py
@@ -137,13 +137,13 @@ def cli():
 	)
 	export_parser.set_defaults(func=export)
 
-	update_parser = subparsers.add_parser('update',
-		help='Update KLibs to the newest available version',
-		usage='klibs update [branch] [-h]'
+	update_parser = subparsers.add_parser('update', formatter_class=CustomHelpFormatter,
+		help='Update KLibs to the latest available version',
+		usage='klibs update [-b <branch>] [-h]'
 	)
-	update_parser.add_argument('branch', default='default', nargs="?", type=str,
-		help=("The branch of the KLibs GitHub repository from which to install the latest version. "
-		"The default branch is used if none is specified.")
+	update_parser.add_argument('-b', '--branch', nargs="?", type=str, metavar="name",
+		help=("The branch of the a-hurst/klibs repository from which to update KLibs. "
+		"Installs the latest stable release if not specified.")
 	)
 	update_parser.set_defaults(func=update)
 

--- a/klibs/__main__.py
+++ b/klibs/__main__.py
@@ -176,6 +176,7 @@ def cli():
 
 	print("") # Add a blank line before any CLI output
 	args["func"](**arg_dict)
+	print("") # Add a blank line after any CLI output
 
 
 if __name__ == '__main__':

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -34,7 +34,6 @@ def ensure_directory_structure(root, create_missing=False):
 			"Resources": ["audio", "code", "font", "image"],
 			"Local": ["logs"],
 			"Data": ["incomplete"],
-			"EDF": ["incomplete"],
 		}
 	}
 
@@ -150,6 +149,8 @@ def create(name, path):
 		("experiment.py", []),
 		(".gitignore", [])
 	]
+
+	# TODO: Prompt user if project involves eye tracking & configure params accordingly
 
 	# Validate name (must be valid Python identifier)
 	valid_name = re.match(re.compile(r"^[A-Za-z_]+([A-Za-z0-9_]+)?$"), name) != None
@@ -453,7 +454,7 @@ def hard_reset(path):
 	for d in reset_dirs:
 		if os.path.isdir(d):
 			shutil.rmtree(d)
-		os.makedirs(d)
+	ensure_directory_structure(path, create_missing=True)
 
 	# Remove (but don't replace) files to reset
 	for f in reset_files:

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -233,6 +233,11 @@ def create(name, path):
 
 def run(screen_size, path, condition, devmode, no_tracker, seed):
 
+	# Ensure the specified screen size is valid
+	if screen_size <= 0:
+		err("Invalid screen size '{0}'. Size must be the diagonal size of the screen\n"
+			"in inches (e.g. 'klibs run 24' for a 24-inch screen).".format(screen_size))
+
 	cso("\n<green>*** Now Loading KLibs Environment ***</green>\n")
 
 	# Suppresses possible pysdl2-dll warning message on import

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -409,7 +409,10 @@ def hard_reset(path):
 	from klibs.KLUtilities import iterable
 
 	# Sanitize and switch to path, exiting with error if not a KLibs project directory
-	initialize_path(path)
+	project_name = initialize_path(path)
+
+	# Initialize file paths for the project
+	P.initialize_paths(project_name)
 
 	reset_prompt = cso(
 		"\n<red>Warning: doing a hard reset will delete all collected data, "
@@ -425,11 +428,13 @@ def hard_reset(path):
 				shutil.rmtree(join(path, "ExpAssets", d))
 			except OSError:
 				pass
+		for f in [P.database_path, P.database_backup_path]:
+			if os.path.isfile(f):
+				os.remove(f)
 		os.makedirs(join(path, "ExpAssets", "Data", "incomplete"))
 		os.makedirs(join(path, "ExpAssets", "EDF", "incomplete"))
 		os.mkdir(join(path, "ExpAssets", "Local", "logs"))
 		os.mkdir(join(path, "ExpAssets", ".versions"))
-		rebuild_db(path)
 	print("")
 
 

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -57,7 +57,8 @@ def ensure_directory_structure(root, create_missing=False):
 	if create_missing:
 		for d in missing_dirs:
 			dpath = os.path.join(root, d)
-			os.makedirs(dpath, exist_ok=True)
+			if not os.path.isdir(dpath):
+				os.makedirs(dpath)
 
 	return missing_dirs
 

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -5,7 +5,7 @@ import re
 import sys
 import traceback
 
-from klibs.KLInternal import load_source
+from klibs.KLInternal import load_source, full_trace
 from klibs.KLInternal import colored_stdout as cso
 from klibs import P
 
@@ -389,6 +389,7 @@ def export(path, table=None, combined=False, join=None):
 	# Validate database path and export
 	P.database_path = validate_database_path(P.database_path)
 	DatabaseManager().export(table, multi_file, join)
+	print("") # newline between export info and next prompt for aesthetics' sake
 
 
 def rebuild_db(path):
@@ -407,7 +408,19 @@ def rebuild_db(path):
 
 	# Validate database path and rebuild
 	P.database_path = validate_database_path(P.database_path)
-	DatabaseManager().rebuild()
+	try:
+		DatabaseManager().rebuild()
+		cso("Database successfully rebuilt! Please make sure to update experiment.py\n"
+			"to reflect any changes you might have made to tables or column names.\n")
+	except Exception as e:
+		exc_txt = traceback.format_exc().split("\n")[-2]
+		schema_filename = os.path.basename(P.schema_file_path)
+		err = (
+			"<red>Syntax error encountered in database schema ('{0}'):</red>\n\n"
+			"  {1}\n\n"
+			"<red>Please double-check the file's formatting and try again.</red>\n"
+		)
+		cso(err.format(schema_filename, exc_txt))
 
 
 def hard_reset(path):

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -3,16 +3,22 @@ __author__ = 'Austin Hurst & Jonathan Mulle'
 import os
 import re
 import sys
-import time
 import traceback
 
 from klibs.KLInternal import load_source
-from klibs.KLUtilities import colored_stdout as cso
-from klibs.KLUtilities import getinput
+from klibs.KLInternal import colored_stdout as cso
 from klibs import P
 
 
 # Utility Functions #
+
+def getinput(*args, **kwargs):
+	# Python 2/3-agnostic function for getting console input.
+	try:
+		return raw_input(*args, **kwargs)
+	except NameError:
+		return input(*args, **kwargs)
+
 
 def err(err_string):
 	cso("<red>\nError: " + err_string + "</red>\n")
@@ -406,7 +412,7 @@ def rebuild_db(path):
 def hard_reset(path):
 	import shutil
 	from os.path import join
-	from klibs.KLUtilities import iterable
+	from klibs.KLInternal import iterable
 
 	# Sanitize and switch to path, exiting with error if not a KLibs project directory
 	project_name = initialize_path(path)

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -235,6 +235,12 @@ def run(screen_size, path, condition, devmode, no_tracker, seed):
 
 	cso("\n<green>*** Now Loading KLibs Environment ***</green>\n")
 
+	# Suppresses possible pysdl2-dll warning message on import
+	import warnings
+	with warnings.catch_warnings():	
+		warnings.simplefilter("ignore")
+		import sdl2
+
 	from klibs import P
 	from klibs import env
 	from klibs.KLGraphics.core import display_init

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -383,7 +383,6 @@ def export(path, table=None, combined=False, join=None):
 	# Validate database path and export
 	P.database_path = validate_database_path(P.database_path)
 	DatabaseManager().export(table, multi_file, join)
-	print("") # newline between export info and next prompt for aesthetics' sake
 
 
 def rebuild_db(path):
@@ -405,14 +404,14 @@ def rebuild_db(path):
 	try:
 		DatabaseManager().rebuild()
 		cso("Database successfully rebuilt! Please make sure to update experiment.py\n"
-			"to reflect any changes you might have made to tables or column names.\n")
+			"to reflect any changes you might have made to tables or column names.")
 	except Exception as e:
 		exc_txt = traceback.format_exc().split("\n")[-2]
 		schema_filename = os.path.basename(P.schema_file_path)
 		err = (
 			"<red>Syntax error encountered in database schema ('{0}'):</red>\n\n"
 			"  {1}\n\n"
-			"<red>Please double-check the file's formatting and try again.</red>\n"
+			"<red>Please double-check the file's formatting and try again.</red>"
 		)
 		cso(err.format(schema_filename, exc_txt))
 
@@ -450,7 +449,7 @@ def hard_reset(path):
 		if os.path.isfile(f):
 			os.remove(f)
 	
-	cso("\nProject reset successfully.\n")
+	cso("\nProject reset successfully.")
 
 
 def update(branch=None):
@@ -476,7 +475,6 @@ def update(branch=None):
 		False
 	)
 	if getinput(update_prompt).lower() != "y":
-		print("")
 		return
 
 	# Set environment variable to avoid pip update warnings & run update command
@@ -488,6 +486,6 @@ def update(branch=None):
 
 	# Indicate whether update succeeded
 	if p.returncode != 0:
-		cso("\n<red>Errors encountered during KLibs update.</red>\n")
+		cso("\n<red>Errors encountered during KLibs update.</red>")
 	else:
-		cso("\n<green_d>Update completed successfully!</green_d>\n")
+		cso("\n<green_d>Update completed successfully!</green_d>")

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -21,7 +21,7 @@ def getinput(*args, **kwargs):
 
 
 def err(err_string):
-	cso("<red>\nError: " + err_string + "</red>\n")
+	cso("<red>Error: " + err_string + "</red>\n")
 	sys.exit()
 
 
@@ -93,7 +93,7 @@ def validate_database_path(db_path, prompt=False):
 			"or may not exist yet.".format(db_path))
 
 	while not os.path.isfile(db_path):
-		cso("\n<green_d>No database file was present at '{0}'.</green_d>".format(db_path))
+		cso("<green_d>No database file was present at '{0}'.</green_d>".format(db_path))
 		db_prompt = cso(
 			"<green_d>You can "
 			"<purple>(c)</purple>reate it, "
@@ -101,18 +101,18 @@ def validate_database_path(db_path, prompt=False):
 			"<purple>(q)</purple>uit: </green_d>", print_string=False
 		)
 		response = getinput(db_prompt).lower()
+		print("")
 		
 		while response not in ['c', 's', 'q']:
-			err_prompt = cso("<red>\nPlease respond with one of 'c', 's', or 'q': </red>", False)
+			err_prompt = cso("<red>Please respond with one of 'c', 's', or 'q': </red>", False)
 			response = getinput(err_prompt).lower()
 
 		if response == "c":
 			open(db_path, "a").close()
 		elif response == "s":
-			db_path = getinput(cso("<green_d>\nGreat, where might it be?: </green_d>", False))
+			db_path = getinput(cso("<green_d>Great, where might it be?: </green_d>", False))
 			db_path = os.path.normpath(db_path)
 		elif response == "q":
-			print("")
 			sys.exit()
 	
 	return db_path
@@ -171,7 +171,7 @@ def create(name, path):
 			"your project a different name and try again.".format(name, path))
 
 	# Get author name for adding to project files
-	author = getinput(cso("\n<green_d>Please provide your first and last name: </green_d>", False))
+	author = getinput(cso("<green_d>Please provide your first and last name: </green_d>", False))
 	if len(author.split()) < 2:
 		one_name_peeps = ["Madonna", "Prince", "Cher", "Bono", "Sting"]
 		cso("<red>\nOk {0}, take it easy.</red> "
@@ -229,7 +229,7 @@ def create(name, path):
 
 def run(screen_size, path, condition, devmode, no_tracker, seed):
 
-	cso("\n\n<green>*** Now Loading KLibs Environment ***</green>\n")
+	cso("\n<green>*** Now Loading KLibs Environment ***</green>\n")
 
 	from klibs import P
 	from klibs import env
@@ -372,6 +372,7 @@ def export(path, table=None, combined=False, join=None):
 
 	# Sanitize and switch to path, exiting with error if not a KLibs project directory
 	project_name = initialize_path(path)
+	cso("\n<green>*** Exporting data from {0} ***</green>\n".format(project_name))
 
 	# set initial param values for project's context
 	P.initialize_paths(project_name)
@@ -423,7 +424,7 @@ def hard_reset(path):
 	]
 
 	reset_prompt = cso(
-		"\n<red>Warning: doing a hard reset will delete all collected data, "
+		"<red>Warning: doing a hard reset will delete all collected data, "
 		"all logs, all copies of experiment.py and Config files in the .versions folder "
 		"that previous participants were run with, and reset the project's database. "
 		"Are you sure you want to continue?</red> (Y/N): ", False
@@ -442,7 +443,7 @@ def hard_reset(path):
 		if os.path.isfile(f):
 			os.remove(f)
 	
-	cso("\nProject reset successfully.")
+	cso("\nProject reset successfully.\n")
 
 
 def update(branch='default'):
@@ -474,7 +475,7 @@ def update(branch='default'):
 	
 	update_cmd = 'install -U git+{0}#egg=klibs --upgrade-strategy only-if-needed'.format(git_repo)
 	update_prompt = cso(
-		"\n<green_d>Updating will replace the current install of KLibs with the most "
+		"<green_d>Updating will replace the current install of KLibs with the most "
 		"recent commit of the <purple>{0}</purple> branch of <purple>'{1}'</purple>. "
 		"Are you sure you want to continue? (Y/N): </green_d>".format(branch, git_repo_short),
 		False

--- a/klibs/tests/test_cli.py
+++ b/klibs/tests/test_cli.py
@@ -72,20 +72,10 @@ def test_ensure_directory_structure(tmpdir):
 
     global _input_queue
     tmpdir = str(tmpdir)
-    dir_structure = {
-		"ExpAssets": {
-			".versions": None,
-			"Config": None,
-			"Resources": {"audio": None, "code": None, "font": None, "image": None},
-			"Local": {"logs": None},
-			"Data": {"incomplete": None},
-			"EDF": {"incomplete": None}
-		}
-	}
     exp_path = create_experiment("TestExpt", tmpdir)
 
     # Make sure no folders missing from freshly-created project
-    missing = cli.ensure_directory_structure(dir_structure, exp_path)
+    missing = cli.ensure_directory_structure(exp_path)
     assert len(missing) == 0
 
     # Remove some folders and make sure they're noticed
@@ -93,14 +83,14 @@ def test_ensure_directory_structure(tmpdir):
     datapath = os.path.join(exp_path, "ExpAssets", "Data")
     shutil.rmtree(logpath)
     shutil.rmtree(datapath)
-    missing = cli.ensure_directory_structure(dir_structure, exp_path)
+    missing = cli.ensure_directory_structure(exp_path)
     assert len(missing) == 3
     assert "logs" in [os.path.basename(f) for f in missing]
     assert "Data" in [os.path.basename(f) for f in missing]
 
     # Try creating the missing folders
-    cli.ensure_directory_structure(dir_structure, exp_path, create_missing=True)
-    missing = cli.ensure_directory_structure(dir_structure, exp_path)
+    cli.ensure_directory_structure(exp_path, create_missing=True)
+    missing = cli.ensure_directory_structure(exp_path)
     assert len(missing) == 0
     assert os.path.isdir(logpath)
     assert os.path.isdir(datapath)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
 	url='http://github.com/a-hurst/klibs',
 	packages=['klibs', 'klibs/KLGraphics', 'klibs/KLEyeTracking'],
 	include_package_data=True,
-	entry_points = {'console_scripts': ['klibs = klibs.__main__:cli']},
+	entry_points = {'console_scripts': ['klibs = klibs.__main__:klibs_main']},
 	python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
 	install_requires=[
 		'numpy>=1.8.0rc1', 


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR cleans up the KLibs CLI code and fixes a few bugs, but also makes the klibs CLI interface *much* faster to use by ensuring SDL2 and other external dependencies don't need to be loaded unless actually running an experiment. This means that `klibs -h` shows the help text near-instantly instead of having noticeable lag, and functions like `klibs export` and `klibs db-rebuild` are notably more responsive.

Apart from ensuring the main CLI  only loads slower dependencies during actual runtime, the other main architectural change here is that the CLI code for handling and prompting users about a missing database has been moved to `cli.py`, meaning that all user-facing CLI functionality are now contained in `cli.py` and `__main__.py`.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
