### PR TITLE
Clean up and reorganize KLUtilities

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -135,6 +135,12 @@ API Changes:
   :func:`~klibs.KLUserInterface.smart_sleep` functions to the 
   :mod:`klibs.KLUserInterface` module. For legacy code, these functions can
   still be imported from :mod:`klibs.KLUtilities`.
+* Removed deprecated legacy functions :func:`arg_error_str`,
+  :func:`bool_to_int`, :func:`camel_to_snake`, :func:`indices_of`,
+  :func:`list_dimensions`, :func:`mouse_angle`, :func:`sdl_key_code_to_str`,
+  :func:`snake_to_camel`, :func:`snake_to_title`, :func:`str_pad`, :func:`log`,
+  and :func:`type_str` from the :mod:`klibs.KLUtilities` module.
+
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -129,9 +129,12 @@ API Changes:
   :func:`~klibs.KLEventQueue.flush` to a new module :mod:`klibs.KLEventQueue`.
   For legacy code, these functions can still be imported from
   :mod:`klibs.KLUtilities`.
-* Moved the :func:`~klibs.KLUserInterface.show_mouse_cursor`,
-  :func:`~klibs.KLUserInterface.hide_mouse_cursor`,
-  :func:`~klibs.KLUserInterface.mouse_pos`, and
+* Renamed the :func:`show_mouse_cursor` and :func:`hide_mouse_cursor` functions
+  to :func:`~klibs.KLUserInterface.show_cursor` and
+  :func:`~klibs.KLUserInterface.hide_cursor`, respectively, and moved them to
+  the :mod:`klibs.KLUserInterface` module. For legacy code, both functions can
+  still be imported by their old names from :mod:`klibs.KLUtilities`.
+* Moved the :func:`~klibs.KLUserInterface.mouse_pos` and
   :func:`~klibs.KLUserInterface.smart_sleep` functions to the 
   :mod:`klibs.KLUserInterface` module. For legacy code, these functions can
   still be imported from :mod:`klibs.KLUtilities`.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -125,6 +125,16 @@ API Changes:
 * :obj:`~klibs.KLBoundary.RectangleBoundary` objects no longer raise an error
   if ``p2`` is above or to the left of ``p1`` and instead swaps the x and y
   values such that ``p1`` is always the top-leftmost coordinate.
+* Moved the :func:`~klibs.KLEventQueue.pump` and
+  :func:`~klibs.KLEventQueue.flush` to a new module :mod:`klibs.KLEventQueue`.
+  For legacy code, these functions can still be imported from
+  :mod:`klibs.KLUtilities`.
+* Moved the :func:`~klibs.KLUserInterface.show_mouse_cursor`,
+  :func:`~klibs.KLUserInterface.hide_mouse_cursor`,
+  :func:`~klibs.KLUserInterface.mouse_pos`, and
+  :func:`~klibs.KLUserInterface.smart_sleep` functions to the 
+  :mod:`klibs.KLUserInterface` module. For legacy code, these functions can
+  still be imported from :mod:`klibs.KLUtilities`.
 
 
 Fixed Bugs:

--- a/klibs/KLAudio.py
+++ b/klibs/KLAudio.py
@@ -19,7 +19,8 @@ from klibs.KLEnvironment import EnvAgent
 from klibs.KLConstants import AR_CHUNK_READ_SIZE, AR_CHUNK_SIZE, AR_RATE
 from klibs import P
 from klibs.KLInternal import hide_stderr
-from klibs.KLUtilities import pump, flush, peak
+from klibs.KLEventQueue import pump, flush
+from klibs.KLUtilities import peak
 from klibs.KLTime import CountDown
 from klibs.KLUserInterface import ui_request, key_pressed, any_key
 from klibs.KLGraphics.KLDraw import Ellipse

--- a/klibs/KLCommunication.py
+++ b/klibs/KLCommunication.py
@@ -18,7 +18,8 @@ from klibs.KLConstants import (AUTO_POS, BL_CENTER, BL_TOP_LEFT, QUERY_ACTION_UP
 	QUERY_ACTION_HASH)
 import klibs.KLParams as P
 from klibs.KLJSON_Object import import_json, AttributeDict
-from klibs.KLUtilities import pretty_list, now, pump, flush, iterable, utf8, make_hash
+from klibs.KLEventQueue import pump, flush
+from klibs.KLUtilities import pretty_list, now, iterable, utf8, make_hash
 from klibs.KLUtilities import colored_stdout as cso
 from klibs.KLDatabase import EntryTemplate
 from klibs.KLRuntimeInfo import runtime_info_init

--- a/klibs/KLConstants.py
+++ b/klibs/KLConstants.py
@@ -119,9 +119,6 @@ QUERY_INS = "insert"
 QUERY_UPD = "update"
 QUERY_DEL = "delete"
 QUERY_SEL = "select"
-DB_COL_SNAKE = "snake_case"
-DB_COL_CAMEL = "camelCase"
-DB_COL_TITLE = "TitleCase"
 
 # AudioResponse Constants
 AR_CHUNK_SIZE = 1024

--- a/klibs/KLDatabase.py
+++ b/klibs/KLDatabase.py
@@ -9,7 +9,7 @@ from itertools import chain
 from collections import OrderedDict
 
 from klibs.KLEnvironment import EnvAgent
-from klibs.KLConstants import (DB_CREATE, DB_COL_TITLE, DB_SUPPLY_PATH, SQL_COL_DELIM_STR,
+from klibs.KLConstants import (DB_CREATE, DB_SUPPLY_PATH, SQL_COL_DELIM_STR,
 	SQL_NUMERIC, SQL_FLOAT, SQL_REAL, SQL_INT, SQL_BOOL, SQL_STR, SQL_BIN, SQL_KEY, SQL_NULL,
 	PY_INT, PY_FLOAT, PY_BOOL, PY_BIN, PY_STR, QUERY_SEL, TAB, ID)
 from klibs import P

--- a/klibs/KLEventQueue.py
+++ b/klibs/KLEventQueue.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+__author__ = 'Jonathan Mulle & Austin Hurst'
+
+"""This module contains functions for updating, fetching, and clearing the input
+event queue.
+
+The input event queue contains events representing key presses, mouse movements, mouse
+clicks, joystick events, and more. For example, if you press and release the 'z' key on
+the keyboard, a 'key down' event will be added to the event queue when the key is first
+pressed and a 'key up' event will be added when the key is released.
+
+In order to read and react to input events in your experiment, you need to fetch the
+contents of the queue with the :func:`pump` function and either handle them directly
+or pass the queue contents to a function that processes input events (e.g.
+:func:`~klibs.KLUserInterface.key_pressed`).
+
+"""
+
+# TODO: Consider whether additional functions/objects would be useful
+
+from sdl2 import SDL_PumpEvents, SDL_FlushEvents, SDL_FIRSTEVENT, SDL_LASTEVENT
+from sdl2.ext import get_events
+
+
+def pump(return_events=False):
+	"""Updates (and optionally retrieves) the contents of the input event queue.
+	
+	In general, ``pump(True)`` is usually called at the start of a loop checking
+	for input::
+
+		flush() # Clear the input queue before starting the loop
+		response = None
+		start_time = precise_time()
+		while (precise_time() - start_time) < 5.0 and not response:
+
+			q = pump(True) # Retrieve the current input queue contents
+
+			if key_pressed('z', queue=q):
+				response = 'left'
+			elif key_pressed('/', queue=q):
+				response = 'right'
+
+	Note that calling ``pump(True)`` both returns and clears the contents of the
+	event queue, so make sure to call it only once per loop to avoid missing
+	input events.
+
+	Calling ``pump(False)`` will update the current state of different input
+	devices (e.g. the mouse cursor position, joystick button/axis states) but
+	will not fetch or clear any events from the queue.
+
+	Args:
+		return_events (bool): If True, returns the contents of the input event queue.
+
+	Returns:
+		list or None: A list of SDL_Event objects if return_events is True,
+		otherwise ``None``.
+
+	"""
+    # NOTE: get_events() empties queue, SDL_PumpEvents() doesn't
+	SDL_PumpEvents()
+	if return_events:
+		return get_events()
+
+
+def flush():
+	"""Clears all unprocessed events from the input event queue.
+	
+	This should be called before any loops that check for input to ensure they
+	are not disrupted by earlier input events.
+	
+	"""
+	SDL_PumpEvents() # Ensures all pending system events are added to event queue
+	SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT)

--- a/klibs/KLExperiment.py
+++ b/klibs/KLExperiment.py
@@ -80,7 +80,7 @@ class Experiment(EnvAgent):
 		Private method; manages a trial.
 		"""
 		from klibs.KLEventQueue import pump
-		from klibs.KLUtilities import show_mouse_cursor, hide_mouse_cursor
+		from klibs.KLUserInterface import show_cursor, hide_cursor
 
 		# At start of every trial, before setup_response_collector or trial_prep are run, retrieve
 		# the values of the independent variables (factors) for that trial (as generated earlier by
@@ -96,7 +96,7 @@ class Experiment(EnvAgent):
 		tx = None
 		try:
 			if P.development_mode and (P.dm_trial_show_mouse or (P.eye_tracking and not P.eye_tracker_available)):
-				show_mouse_cursor()
+				show_cursor()
 			self.evm.start_clock()
 			if P.eye_tracking and not P.manual_eyelink_recording:
 				self.el.start(P.trial_number)
@@ -106,7 +106,7 @@ class Experiment(EnvAgent):
 			if P.eye_tracking and not P.manual_eyelink_recording:
 				self.el.stop()
 			if P.development_mode and (P.dm_trial_show_mouse or (P.eye_tracking and not P.eye_tracker_available)):
-				hide_mouse_cursor()
+				hide_cursor()
 			self.evm.stop_clock()
 			self.trial_clean_up()
 		except TrialException as e:

--- a/klibs/KLExperiment.py
+++ b/klibs/KLExperiment.py
@@ -79,7 +79,8 @@ class Experiment(EnvAgent):
 		"""
 		Private method; manages a trial.
 		"""
-		from klibs.KLUtilities import pump, show_mouse_cursor, hide_mouse_cursor
+		from klibs.KLEventQueue import pump
+		from klibs.KLUtilities import show_mouse_cursor, hide_mouse_cursor
 
 		# At start of every trial, before setup_response_collector or trial_prep are run, retrieve
 		# the values of the independent variables (factors) for that trial (as generated earlier by
@@ -329,7 +330,7 @@ class Experiment(EnvAgent):
 
 
 	def show_logo(self):
-		from klibs.KLUtilities import flush
+		from klibs.KLEventQueue import flush
 		from klibs.KLUserInterface import any_key
 		from klibs.KLGraphics import fill, blit, flip
 		from klibs.KLGraphics import NumpySurface as NpS

--- a/klibs/KLEyeTracking/KLCustomEyeLinkDisplay.py
+++ b/klibs/KLEyeTracking/KLCustomEyeLinkDisplay.py
@@ -12,9 +12,9 @@ from math import ceil, floor
 from klibs.KLEnvironment import EnvAgent
 from klibs.KLConstants import EYELINK_1000
 from klibs import P
-from klibs.KLUtilities import clip, mouse_pos
+from klibs.KLUtilities import clip
 from klibs.KLEventQueue import pump
-from klibs.KLUserInterface import ui_request
+from klibs.KLUserInterface import ui_request, mouse_pos
 from klibs.KLGraphics import fill, flip, blit
 from klibs.KLGraphics.KLDraw import drift_correct_target
 from klibs.KLCommunication import message

--- a/klibs/KLEyeTracking/KLCustomEyeLinkDisplay.py
+++ b/klibs/KLEyeTracking/KLCustomEyeLinkDisplay.py
@@ -12,7 +12,8 @@ from math import ceil, floor
 from klibs.KLEnvironment import EnvAgent
 from klibs.KLConstants import EYELINK_1000
 from klibs import P
-from klibs.KLUtilities import pump, mouse_pos, clip
+from klibs.KLUtilities import clip, mouse_pos
+from klibs.KLEventQueue import pump
 from klibs.KLUserInterface import ui_request
 from klibs.KLGraphics import fill, flip, blit
 from klibs.KLGraphics.KLDraw import drift_correct_target

--- a/klibs/KLEyeTracking/KLEyeLink.py
+++ b/klibs/KLEyeTracking/KLEyeLink.py
@@ -15,8 +15,7 @@ from klibs.KLConstants import (EL_LEFT_EYE, EL_RIGHT_EYE, EL_BOTH_EYES, EL_NO_EY
 from klibs import P
 from klibs.KLInternal import full_trace, valid_coords, now, hide_stderr
 from klibs.KLInternal import colored_stdout as cso
-from klibs.KLUserInterface import ui_request
-from klibs.KLUtilities import hide_mouse_cursor
+from klibs.KLUserInterface import ui_request, hide_cursor
 from klibs.KLGraphics import blit, fill, flip, clear
 from klibs.KLGraphics.KLDraw import drift_correct_target
 from klibs.KLEyeTracking.KLEyeTracker import EyeTracker
@@ -260,7 +259,7 @@ class EyeLink(BaseEyeLink, EyeTracker):
 				perform the drift correct.
 
 		"""
-		hide_mouse_cursor()
+		hide_cursor()
 
 		target = drift_correct_target() if target is None else target
 		draw_target = EL_TRUE if draw_target in [EL_TRUE, True] else EL_FALSE

--- a/klibs/KLEyeTracking/KLTryLink.py
+++ b/klibs/KLEyeTracking/KLTryLink.py
@@ -9,11 +9,12 @@ from klibs.KLConstants import (EL_LEFT_EYE, EL_RIGHT_EYE, EL_BOTH_EYES, EL_NO_EY
 	EL_ALL_EVENTS, EL_TRUE, EL_FALSE,
 	TK_S, TK_MS, CIRCLE_BOUNDARY, RECT_BOUNDARY)
 from klibs import P
-from klibs.KLUtilities import (pump, mouse_pos, show_mouse_cursor, hide_mouse_cursor,
+from klibs.KLUtilities import (mouse_pos, show_mouse_cursor, hide_mouse_cursor,
 	iterable, now, mean)
 from klibs.KLBoundary import CircleBoundary
 from klibs.KLGraphics import fill, blit, flip
 from klibs.KLGraphics.KLDraw import drift_correct_target
+from klibs.KLEventQueue import pump
 from klibs.KLUserInterface import ui_request
 from klibs.KLEyeTracking.KLEyeTracker import EyeTracker
 from klibs.KLEyeTracking.events import GazeSample, EyeEvent, EyeEventTemplate

--- a/klibs/KLEyeTracking/KLTryLink.py
+++ b/klibs/KLEyeTracking/KLTryLink.py
@@ -9,13 +9,12 @@ from klibs.KLConstants import (EL_LEFT_EYE, EL_RIGHT_EYE, EL_BOTH_EYES, EL_NO_EY
 	EL_ALL_EVENTS, EL_TRUE, EL_FALSE,
 	TK_S, TK_MS, CIRCLE_BOUNDARY, RECT_BOUNDARY)
 from klibs import P
-from klibs.KLUtilities import (mouse_pos, show_mouse_cursor, hide_mouse_cursor,
-	iterable, now, mean)
+from klibs.KLUtilities import iterable, now, mean
 from klibs.KLBoundary import CircleBoundary
 from klibs.KLGraphics import fill, blit, flip
 from klibs.KLGraphics.KLDraw import drift_correct_target
 from klibs.KLEventQueue import pump
-from klibs.KLUserInterface import ui_request
+from klibs.KLUserInterface import ui_request, mouse_pos, show_cursor, hide_cursor
 from klibs.KLEyeTracking.KLEyeTracker import EyeTracker
 from klibs.KLEyeTracking.events import GazeSample, EyeEvent, EyeEventTemplate
 
@@ -245,7 +244,7 @@ class TryLink(EyeTracker):
 				Defaults to True.
 
 		"""
-		show_mouse_cursor()
+		show_cursor()
 
 		target = drift_correct_target() if target is None else target
 		draw_target = EL_TRUE if draw_target in [EL_TRUE, True] else EL_FALSE
@@ -265,7 +264,7 @@ class TryLink(EyeTracker):
 				SDL_Delay(2) # required for pump() to reliably return mousebuttondown events
 			for e in event_queue:
 				if e.type == SDL_MOUSEBUTTONDOWN and dc_boundary.within([e.button.x, e.button.y]):
-					hide_mouse_cursor()
+					hide_cursor()
 					if draw_target == EL_TRUE:
 						fill(P.default_fill_color if not fill_color else fill_color)
 						flip()

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -13,7 +13,8 @@ from klibs.KLConstants import (RC_AUDIO, RC_COLORSELECT, RC_DRAW, RC_KEYPRESS,
 	NO_RESPONSE, TIMEOUT, TK_S, TK_MS)
 from klibs import P
 from klibs.KLKeyMap import KeyMap
-from klibs.KLUtilities import (pump, flush, hide_mouse_cursor, show_mouse_cursor, mouse_pos,
+from klibs.KLEventQueue import pump, flush
+from klibs.KLUtilities import (hide_mouse_cursor, show_mouse_cursor, mouse_pos,
 	full_trace, iterable, angle_between)
 from klibs.KLUserInterface import ui_request
 from klibs.KLBoundary import BoundarySet, AnnulusBoundary

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -14,9 +14,8 @@ from klibs.KLConstants import (RC_AUDIO, RC_COLORSELECT, RC_DRAW, RC_KEYPRESS,
 from klibs import P
 from klibs.KLKeyMap import KeyMap
 from klibs.KLEventQueue import pump, flush
-from klibs.KLUtilities import (hide_mouse_cursor, show_mouse_cursor, mouse_pos,
-	full_trace, iterable, angle_between)
-from klibs.KLUserInterface import ui_request
+from klibs.KLUtilities import full_trace, iterable, angle_between
+from klibs.KLUserInterface import ui_request, hide_cursor, show_cursor, mouse_pos
 from klibs.KLBoundary import BoundarySet, AnnulusBoundary
 from klibs.KLGraphics import flip
 from klibs.KLGraphics.utils import aggdraw_to_array
@@ -611,7 +610,7 @@ class CursorResponse(ResponseListener, BoundarySet):
 		if len(self.boundaries) == 0:
 			e = "The ClickResponse listener must contain at least one boundary to check."
 			raise BoundaryError(e)
-		show_mouse_cursor()
+		show_cursor()
 
 	def listen(self, event_queue):
 		"""See :meth:`ResponseListener.listen`.
@@ -632,7 +631,7 @@ class CursorResponse(ResponseListener, BoundarySet):
 
 		"""
 		if not (P.development_mode and P.dm_trial_show_mouse):
-			hide_mouse_cursor()
+			hide_cursor()
 
 	@property
 	def on_release(self):
@@ -719,7 +718,7 @@ class ColorWheelResponse(ResponseListener):
 		if not self.angle_response and not self.color_response:
 			raise ValueError("At least one of 'angle_response' and 'color_response' must be True.")
 		# Show cursor on screen and optionally warp cursor to the center of the wheel
-		show_mouse_cursor()
+		show_cursor()
 		if self.warp_cursor:
 			mouse_pos(position = self.__bounds.center)
 
@@ -754,7 +753,7 @@ class ColorWheelResponse(ResponseListener):
 
 		"""
 		if not (P.development_mode and P.dm_trial_show_mouse):
-			hide_mouse_cursor()	
+			hide_cursor()	
 
 	def set_target(self, target):
 		'''Sets the colour probe Drawbject or target location for listener, which is used to
@@ -905,9 +904,9 @@ class DrawResponse(ResponseListener, BoundarySet):
 			raise ValueError("Start and stop boundaries must be provided for draw listeners.")
 		# Make cursor visible or invisible at collection start, depending on listener options
 		if self.show_inactive_cursor:
-			show_mouse_cursor()
+			show_cursor()
 		else:
-			hide_mouse_cursor()
+			hide_cursor()
 
 
 	def listen(self, event_queue=None):
@@ -925,9 +924,9 @@ class DrawResponse(ResponseListener, BoundarySet):
 				self.started = True
 				self.start_time = self.evm.trial_time
 				if self.show_active_cursor:
-					show_mouse_cursor()
+					show_cursor()
 				else:
-					hide_mouse_cursor()
+					hide_cursor()
 
 		# If started and within stop boundary, check if stop eligible and stop if so
 		elif self.within_boundary(self.stop_boundary, mp):

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -85,15 +85,19 @@ def key_pressed(key=None, queue=None):
 	return pressed
 
 
-def show_mouse_cursor():
-	"""Unhides the mouse cursor if it is currently hidden. Otherwise, this function does nothing.
+def show_cursor():
+	"""Shows the mouse cursor if it is currently hidden.
+	
+	If the cursor is already visible, this function does nothing.
 
 	"""
 	SDL_ShowCursor(SDL_ENABLE)
 
 
-def hide_mouse_cursor():
-	"""Hides the mouse cursor if it is currently shown. Otherwise, this function does nothing.
+def hide_cursor():
+	"""Hides the mouse cursor if it is currently visible.
+	
+	If the cursor is already hidden, this function does nothing.
 	
 	"""
 	SDL_ShowCursor(SDL_DISABLE)

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -1,11 +1,13 @@
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
-from sdl2 import (SDL_GetKeyFromName, SDL_KEYUP, SDL_KEYDOWN, SDL_MOUSEBUTTONUP, KMOD_CTRL,
-	KMOD_GUI, SDLK_UP, SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, SDLK_a, SDLK_b, SDLK_c, SDLK_p, SDLK_q)
+
+from sdl2 import (SDL_GetKeyFromName,
+	SDL_KEYUP, SDL_KEYDOWN, SDL_MOUSEBUTTONUP, KMOD_CTRL, KMOD_GUI, SDLK_UP,
+	SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, SDLK_a, SDLK_b, SDLK_c, SDLK_p, SDLK_q)
 
 from klibs import P
 from klibs.KLTime import precise_time as time
-from klibs.KLUtilities import pump
+from klibs.KLEventQueue import pump
 
 
 def any_key(allow_mouse_click=True):

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -1,10 +1,15 @@
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
 
-from sdl2 import (SDL_GetKeyFromName,
+import ctypes
+
+from sdl2 import (SDL_GetKeyFromName, SDL_ShowCursor, SDL_PumpEvents, SDL_BUTTON,
+	SDL_DISABLE, SDL_ENABLE, SDL_BUTTON_LEFT, SDL_BUTTON_RIGHT, SDL_BUTTON_MIDDLE,
 	SDL_KEYUP, SDL_KEYDOWN, SDL_MOUSEBUTTONUP, KMOD_CTRL, KMOD_GUI, SDLK_UP,
 	SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, SDLK_a, SDLK_b, SDLK_c, SDLK_p, SDLK_q)
+from sdl2.mouse import SDL_GetMouseState, SDL_WarpMouseGlobal
 
+from klibs import TK_S, TK_MS
 from klibs import P
 from klibs.KLTime import precise_time as time
 from klibs.KLEventQueue import pump
@@ -78,6 +83,60 @@ def key_pressed(key=None, queue=None):
 				pressed = True
 
 	return pressed
+
+
+def show_mouse_cursor():
+	"""Unhides the mouse cursor if it is currently hidden. Otherwise, this function does nothing.
+
+	"""
+	SDL_ShowCursor(SDL_ENABLE)
+
+
+def hide_mouse_cursor():
+	"""Hides the mouse cursor if it is currently shown. Otherwise, this function does nothing.
+	
+	"""
+	SDL_ShowCursor(SDL_DISABLE)
+
+
+def mouse_pos(pump_event_queue=True, position=None, return_button_state=False):
+	"""Returns the current coordinates of the mouse cursor, or alternatively warps the
+	position of the cursor to a specific location on the screen.
+
+	Args:
+		pump_event_queue (bool, optional): Pumps the SDL2 event queue. See documentation
+			for pump() for more information. Defaults to True.
+		position (None or iter(int,int), optional): The x,y pixel coordinates to warp
+			the cursor to if desired. Defaults to None.
+		return_button_state (bool, optional): If True, return the mouse button currently
+			being pressed (if any) in addition to the current cursor coordinates. Defaults
+			to False.
+
+	Returns:
+		A 2-element Tuple containing the x,y coordinates of the cursor as integer values.
+		If position is not None, this will be the coordinates the cursor was warped to.
+		If return_button_state is True, the function returns a 3-element Tuple containing
+		the x,y coordinates of the cursor and the mouse button state (left pressed = 1,
+		right pressed = 2, middle pressed = 3, none pressed = 0).
+
+	"""
+	if pump_event_queue:
+		SDL_PumpEvents()
+	if not position:
+		x, y = ctypes.c_int(0), ctypes.c_int(0)
+		button_state = SDL_GetMouseState(ctypes.byref(x), ctypes.byref(y))
+		if return_button_state:
+			if (button_state & SDL_BUTTON(SDL_BUTTON_LEFT)): pressed = 1
+			elif (button_state & SDL_BUTTON(SDL_BUTTON_RIGHT)): pressed = 2
+			elif (button_state & SDL_BUTTON(SDL_BUTTON_MIDDLE)): pressed = 3
+			else: pressed = 0
+			return (x.value, y.value, pressed)
+		else:
+			return (x.value, y.value)
+	else:
+		x, y = [int(n) for n in position]
+		SDL_WarpMouseGlobal(x, y)
+		return position
 
 
 def konami_code(callback=None, cb_args={}, queue=None):
@@ -194,3 +253,20 @@ def ui_request(key_press=None, execute=True, queue=None):
 							el.calibrate()
 						return "el_calibrate"
 		return False
+
+
+def smart_sleep(interval, units=TK_MS):
+	"""Stops and waits for a given amount of time, ensuring that any 'quit' or 'calibrate' key
+	commands issued during the wait interval are processed.
+
+	Args:
+		interval (float): The number of units of time to pause execution for.
+		units (int, optional): The time unit of 'interval', must be one of `klibs.TK_S` (seconds)
+			or `klibs.TK_MS` (milliseconds). Defaults to milliseconds.
+			
+	"""
+	if units == TK_MS:
+		interval *= .001
+	start = time()
+	while time() - start < interval:
+		ui_request()

--- a/klibs/KLUtilities.py
+++ b/klibs/KLUtilities.py
@@ -1,22 +1,12 @@
 # -*- coding: utf-8 -*-
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
-import os
 import re
 import math
-import time
-import ctypes
-import datetime
-import traceback
 import base64
 from hashlib import sha512
-from sys import exc_info
 from math import sin, cos, acos, atan2, radians, pi, degrees, ceil
 
-from sdl2 import SDL_PumpEvents, KMOD_SHIFT, KMOD_CAPS
-from sdl2.keyboard import SDL_GetKeyName, SDL_GetModState
-
-from klibs.KLConstants import DATETIME_STAMP, TK_S, TK_MS
 from klibs import P
 from klibs.KLInternal import (
 	boolean_to_logical, colored_stdout, full_trace, log, now, iterable, utf8,
@@ -26,23 +16,10 @@ from klibs.KLEventQueue import pump, flush
 from klibs.KLUserInterface import show_mouse_cursor, hide_mouse_cursor, mouse_pos, smart_sleep
 
 
-def arg_error_str(arg_name, given, expected, kw=True):
-	if kw:
-		err_string = "The keyword argument, '{0}', was expected to be of type '{1}' but '{2}' was given."
-	else:
-		err_string = "The argument, '{0}', was expected to be of type '{1}' but '{2}' was given."
-	return err_string.format(arg_name, type(given), type(expected))
-
 
 def angle_between(origin, p2, rotation=0, clockwise=False):
 	angle = degrees(atan2(p2[1] - origin[1], p2[0] - origin[0])) + (-rotation if clockwise else rotation)
 	return (angle if clockwise else -angle) % 360
-
-
-def bool_to_int(boolean_val):
-	if boolean_val is False: return 0
-	if boolean_val is True: return 1
-	raise ValueError("Non-boolean value passed ('{0}')".format(type(boolean_val)))
 
 
 def bounded_by(pos, left, right, top, bottom):
@@ -50,11 +27,6 @@ def bounded_by(pos, left, right, top, bottom):
 		return (left < pos[0] < right and top < pos[1] < bottom)
 	except TypeError:
 		raise TypeError("'pos' must be [x,y] coordinates, other arguments must be numeric.")
-
-
-def camel_to_snake(string):
-	s = re.sub('([a-z0-9])([A-Z])', r'\1_\2', re.sub('(.)([A-Z][a-z]+)', r'\1_\2', string))
-	return s.lower()
 
 
 def canvas_size_from_points(points, flat=False):
@@ -132,13 +104,6 @@ def deg_to_px(deg, even=False):
 	return int(px)
 
 
-def indices_of(element, container, identity_comparison=False):
-	if identity_comparison:
-		return [i for i, x in enumerate(container) if x is element]
-	else:
-		return [i for i, x in enumerate(container) if x == element]
-
-
 def interpolated_path_len(points):
 	# where points is a list of coordinate tuples
 	path_len = 0
@@ -196,35 +161,6 @@ def line_segment_len(a, b):
 	return math.sqrt(dy**2 + dx**2)
 
 
-def list_dimensions(target, dim=0):
-	"""
-	Tests if testlist is a list and how many dimensions it has
-	returns -1 if it is no list at all, 0 if list is empty
-	and otherwise the dimensions of it
-	http://stackoverflow.com/questions/15985389/python-check-if-list-is-multidimensional-or-one-dimensional, u: bunkus
-	"""
-	if isinstance(target, list):
-		return dim if not len(target) else list_dimensions(target[0], dim + 1)
-	else:
-		return -1 if dim == 0 else dim
-
-
-def log(msg, priority):
-	"""Writes a message to a log file (Note: the way logging in KLibs is handled will probably get
-	rewritten soon, so I'd advise against using this).
-
-	Args:
-		msg (:obj:`str`): The message to record to the log file.
-		priority (int): An integer from 1-10 specifying how important the event is, 1 being most
-			critical and 10 being routine. If set to 0 it will always be printed, regardless of
-			what the user sets verbosity to. You probably shouldn't do that.
-
-	"""
-	if priority <= P.verbosity:
-		with open(P.log_file_path, 'a') as log_file:
-			log_file.write(str(priority) + ": " + msg)
-
-
 def make_hash(x, n_bytes=16):
 	"""Produces a hash string for a given input, with the length of the hash string being
 	determined by the number of bytes (more bytes = longer string).
@@ -271,14 +207,6 @@ def mean(values):
 
 	"""
 	return sum(values) / float(len(values))
-
-
-def mouse_angle(pump_event_queue=True, reference=None, rotation=0, clockwise=False):
-	if pump_event_queue:
-		SDL_PumpEvents()
-	if reference is None:
-		reference = P.screen_c
-	return angle_between(reference, mouse_pos(), rotation, clockwise)
 
 
 def peak(v1, v2):
@@ -479,35 +407,6 @@ def scale(coords, canvas_size, target_size=None, scale=True, center=True):
 	return (x,y)
 
 
-def sdl_key_code_to_str(sdl_keysym):
-	key_name = SDL_GetKeyName(sdl_keysym).replace(b"Keypad ", b"")
-	key_name = str(key_name.decode('utf-8')) # for py3k compatibility
-	if key_name == "Space":
-		return " "
-	if not any(SDL_GetModState() & mod for mod in [KMOD_CAPS, KMOD_SHIFT]):
-		# if not holding Shift or Caps Lock isn't on, make letter lower case.
-		key_name = key_name.lower()
-	return key_name if len(key_name) == 1 else False # if key is not alphanumeric
-
-
-def snake_to_camel(string):
-	words = string.split('_')
-	return words[0] + "".join(x.title() for x in words[1:])
-
-
-def snake_to_title(string):
-	words = string.split('_')
-	return "".join(x.title() for x in words)
-
-
-def str_pad(string, str_len, pad_char=" ", pad_dir="r"):
-	pad_len = str_len - len(string)
-	if pad_len < 1:
-		raise ValueError("Desired string length shorter current string.")
-	padding = "".join([pad_char] * pad_len)
-	return string+padding if pad_dir == "r" else padding+string
-
-
 def translate_points(points, delta, flat=False):
 	"""Translates a list of x,y points in 2d coordinate space.
 
@@ -535,20 +434,6 @@ def translate_points(points, delta, flat=False):
 			dy = point[1] + delta[1]
 			translated.append((dx, dy))
 	return translated
-
-
-def type_str(var):
-	"""Returns the type name of a variable as a string (e.g. 'int' if the passed variable is
-	an int).
-	
-	Args:
-		var: The variable to determine the type of.
-
-	Returns:
-		str: The name of the passed variable's type.
-
-	"""
-	return type(var).__name__
 
 
 def acute_angle(vertex, p1, p2):

--- a/klibs/KLUtilities.py
+++ b/klibs/KLUtilities.py
@@ -13,12 +13,9 @@ from hashlib import sha512
 from sys import exc_info
 from math import sin, cos, acos, atan2, radians, pi, degrees, ceil
 
-from sdl2 import (SDL_Event, SDL_PumpEvents, SDL_PushEvent, SDL_FlushEvents, SDL_RegisterEvents,
-	SDL_PeepEvents, SDL_GetError, SDL_GetTicks,
-	SDL_FIRSTEVENT, SDL_LASTEVENT, SDL_GETEVENT, SDL_MOUSEMOTION, 
+from sdl2 import (SDL_PumpEvents, SDL_GetTicks,
 	SDL_DISABLE, SDL_ENABLE, SDL_BUTTON, SDL_BUTTON_LEFT, SDL_BUTTON_RIGHT, SDL_BUTTON_MIDDLE,
 	KMOD_SHIFT, KMOD_CAPS)
-from sdl2.ext import get_events
 from sdl2.mouse import SDL_ShowCursor, SDL_GetMouseState, SDL_WarpMouseGlobal, SDL_ShowCursor
 from sdl2.keyboard import SDL_GetKeyName, SDL_GetModState
 
@@ -28,6 +25,7 @@ from klibs.KLInternal import (
 	boolean_to_logical, colored_stdout, full_trace, log, now, iterable, utf8,
 	valid_coords
 )
+from klibs.KLEventQueue import pump, flush
 
 
 def arg_error_str(arg_name, given, expected, kw=True):
@@ -134,15 +132,6 @@ def deg_to_px(deg, even=False):
 	else:
 		px = deg * P.ppd
 	return int(px)
-
-
-def flush():
-	"""Empties the event queue of all unprocessed input events. This should be called before
-	any input-checking loops, to avoid any input events from before the loop being processed.
-	
-	"""
-	pump()
-	SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT)
 
 
 def hide_mouse_cursor():
@@ -392,36 +381,6 @@ def point_pos(origin, amplitude, angle, rotation=0, clockwise=False, return_int=
 		err = "point_pos error (start: {0}, amp: {1}, ang: {2}, rot: {3})"
 		print(err.format(origin, amplitude, angle, rotation))
 		raise
-
-
-def pump(return_events=False):
-
-	"""Pumps the SDL2 event queue and appends its contents to the EventManager log.
-	The SDL2 event queue contains SDL_Event objects representing keypresses, mouse
-	movements, mouse clicks, and other input events that have occured since last
-	check.
-
-	Pumping the SDL2 event queue clears its contents, so be careful of calling it
-	(or functions that call it implicitly) multiple times in the same loop, as it
-	may result in unexpected problems watching for input (e.g if you have two
-	functions checking for mouse clicks within two different boundaries and both
-	call pump(), the second one will only return True if a click within that boundary
-	occurred within the sub-millisecond interval between the first and second functions.)
-	To avoid these problems, you can manually fetch the queue once per loop and pass its
-	contents to each of the functions in the loop inspecting user input.
-
-	Args:
-		return_events (bool): If true, returns the contents of the SDL2 event queue.
-
-	Returns:
-		A list of SDL_Event objects, if return_events=True. Otherwise, the return 
-		value is None.
-
-	"""
-	SDL_PumpEvents()
-
-	if return_events:
-		return get_events()
 
 
 def pretty_list(items, sep=',', space=' ', before_last='or', brackets='[]', pad=True):

--- a/klibs/KLUtilities.py
+++ b/klibs/KLUtilities.py
@@ -17,6 +17,17 @@ from klibs.KLUserInterface import show_mouse_cursor, hide_mouse_cursor, mouse_po
 
 
 
+def acute_angle(vertex, p1, p2):
+	# this is poorly named: acute angle is any angle under 90 degrees, but this function
+	# calculates the angle between the two lines (vertex -> p1) and (vertex -> p2).
+	# Currently only used once in TraceLab, so can probably rename. Docs would benefit from
+	# an illustration.
+	v_p1 = float(line_segment_len(vertex, p1))
+	v_p2 = float(line_segment_len(vertex, p2))
+	p1_p2 = line_segment_len(p1, p2)
+	return degrees(acos((v_p1**2 + v_p2**2 - p1_p2**2) / (2 * v_p1 * v_p2)))
+
+
 def angle_between(origin, p2, rotation=0, clockwise=False):
 	angle = degrees(atan2(p2[1] - origin[1], p2[0] - origin[0])) + (-rotation if clockwise else rotation)
 	return (angle if clockwise else -angle) % 360
@@ -434,14 +445,3 @@ def translate_points(points, delta, flat=False):
 			dy = point[1] + delta[1]
 			translated.append((dx, dy))
 	return translated
-
-
-def acute_angle(vertex, p1, p2):
-	# this is poorly named: acute angle is any angle under 90 degrees, but this function
-	# calculates the angle between the two lines (vertex -> p1) and (vertex -> p2).
-	# Currently only used once in TraceLab, so can probably rename. Docs would benefit from
-	# an illustration.
-	v_p1 = float(line_segment_len(vertex, p1))
-	v_p2 = float(line_segment_len(vertex, p2))
-	p1_p2 = line_segment_len(p1, p2)
-	return degrees(acos((v_p1**2 + v_p2**2 - p1_p2**2) / (2 * v_p1 * v_p2)))

--- a/klibs/KLUtilities.py
+++ b/klibs/KLUtilities.py
@@ -13,7 +13,9 @@ from klibs.KLInternal import (
 	valid_coords
 )
 from klibs.KLEventQueue import pump, flush
-from klibs.KLUserInterface import show_mouse_cursor, hide_mouse_cursor, mouse_pos, smart_sleep
+from klibs.KLUserInterface import mouse_pos, smart_sleep
+from klibs.KLUserInterface import show_cursor as show_mouse_cursor
+from klibs.KLUserInterface import hide_cursor as hide_mouse_cursor
 
 
 


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR cleans up the rather large and unwieldy KLUtilities module by moving the `pump` and `flush` functions to a new module `KLEventQueue`, moving all input-related functions (e.g. `mouse_pos`) to `KLUserInterface`, and removing a bunch of deprecated and unused legacy functions from the KLUtilities module.

The removed functions should no longer be in use in any published KLibs experiments, but some code may need to be updated for compatibility.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
