### PR TITLE
Tidy and expand KLUserInterface

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -74,8 +74,10 @@ New Features:
 * ``EDF`` folder is no longer created by default for new projects. It is now
   created only if needed when saving data from an eye tracking experiment.
 * Added a new function :func:`~klibs.KLUserInferface.mouse_clicked` to easily
-  check the input event queue for clicks and releases of mouse buttons, similar
-  to :func:`~klibs.KLUserInferface.key_pressed` for the keyboard. 
+  check a given input event queue for clicks and releases of mouse buttons,
+  similar to :func:`~klibs.KLUserInferface.key_pressed` for the keyboard. 
+* Added a new function :func:`~klibs.KLUserInferface.get_clicks` to easily
+  fetch the (x, y) coordinates of any mouse clicks in a given input event queue.
 
 
 API Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -73,6 +73,9 @@ New Features:
   the latest commit from the default branch.
 * ``EDF`` folder is no longer created by default for new projects. It is now
   created only if needed when saving data from an eye tracking experiment.
+* Added a new function :func:`~klibs.KLUserInferface.mouse_clicked` to easily
+  check the input event queue for clicks and releases of mouse buttons, similar
+  to :func:`~klibs.KLUserInferface.key_pressed` for the keyboard. 
 
 
 API Changes:

--- a/klibs/KLBoundary.py
+++ b/klibs/KLBoundary.py
@@ -27,6 +27,31 @@ your own custom boundary shapes by subclassing the :class:`Boundary` object.
 class BoundarySet(object):
 	"""A class for managing and inspecting multiple :class:`Boundary` objects.
 
+	For example, you can use a BoundarySet to check which of three locations
+	a participant's mouse cursor is hovering over::
+
+		from klibs.KLUserInterface import mouse_pos, get_clicks
+
+		# Create boundaries and add to set
+		button1 = RectangleBoundary('yes', (200, 200), (300, 300))
+		button2 = RectangleBoundary('no', (400, 200), (500, 300))
+		button3 = RectangleBoundary('maybe', (600, 200), (700, 300))
+		bounds = BoundarySet([button1, button2, button3])
+
+		# Check which button (if any) mouse is currently over
+		p = mouse_pos()
+		over_boundary = bounds.which_boundary(p)
+		if over_boundary != None:
+			print(over_boundary)
+
+	Additionally, you can check whether a point is within a specific boundary::
+
+		for click in get_clicks():
+			if bounds.within_boundary('yes', click):
+				print("Clicked 'yes'")
+			elif bounds.within_boundary('no', click):
+				print("Clicked 'no'")
+
 	Args:
 		boundaries (:obj:`List`, optional): A list of :obj:`Boundary` objects with which
 			to initialize the boundary set.

--- a/klibs/KLEyeTracking/KLTryLink.py
+++ b/klibs/KLEyeTracking/KLTryLink.py
@@ -14,11 +14,13 @@ from klibs.KLBoundary import CircleBoundary
 from klibs.KLGraphics import fill, blit, flip
 from klibs.KLGraphics.KLDraw import drift_correct_target
 from klibs.KLEventQueue import pump
-from klibs.KLUserInterface import ui_request, mouse_pos, show_cursor, hide_cursor
+from klibs.KLUserInterface import (
+	ui_request, mouse_pos, mouse_clicked, show_cursor, hide_cursor
+)
 from klibs.KLEyeTracking.KLEyeTracker import EyeTracker
 from klibs.KLEyeTracking.events import GazeSample, EyeEvent, EyeEventTemplate
 
-from sdl2 import SDL_MOUSEBUTTONDOWN, SDL_GetTicks, SDL_Delay
+from sdl2 import SDL_GetTicks, SDL_Delay
 from math import atan2, degrees
 
 
@@ -254,21 +256,19 @@ class TryLink(EyeTracker):
 		dc_boundary = CircleBoundary('drift_correct', location, P.screen_y // 30)
 		
 		while True:
-			event_queue = pump(True)
-			ui_request(queue=event_queue)
 			if draw_target == EL_TRUE:
 				fill(P.default_fill_color if not fill_color else fill_color)
 				blit(target, 5, location)
 				flip()
 			else:
 				SDL_Delay(2) # required for pump() to reliably return mousebuttondown events
-			for e in event_queue:
-				if e.type == SDL_MOUSEBUTTONDOWN and dc_boundary.within([e.button.x, e.button.y]):
-					hide_cursor()
-					if draw_target == EL_TRUE:
-						fill(P.default_fill_color if not fill_color else fill_color)
-						flip()
-					return 0
+
+			if mouse_clicked(within=dc_boundary):
+				hide_cursor()
+				if draw_target == EL_TRUE:
+					fill(P.default_fill_color if not fill_color else fill_color)
+					flip()
+				return 0
 
 
 	def gaze(self, return_integers=True, binocular_mode=EL_RIGHT_EYE):

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -131,7 +131,7 @@ def mouse_clicked(button=None, released=False, within=None, queue=None):
 	bounds = within
 	if bounds != None:
 		try:
-			bounds.bounds
+			bounds.within((0, 0))
 		except (AttributeError, NotImplementedError):
 			err = "The provided boundary must be a valid Boundary object."
 			raise TypeError(err)

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -16,14 +16,19 @@ from klibs.KLEventQueue import pump
 
 
 def any_key(allow_mouse_click=True):
-	"""A function that waits until any keyboard (or mouse, if enabled) input is received
-	before returning. Intended for use in situations when you want to require input before
-	progressing through the experiment (e.g. "To start the next block, press any key..."). 
-	Not to be used for response collection (see :mod:`~klibs.KLResponseCollectors`).
+	"""Stops and waits, continuing only after a key has been pressed.
+
+	Intended for use in situations when you want to require input before progressing
+	through the experiment (e.g. "To start the next block, press any key..."). 
+	Not intended for use during time-sensitive response collection (see
+	:mod:`~klibs.KLResponseCollectors`).
+
+	If ``allow_mouse_click`` is True, this function will also return if a mouse
+	button is clicked and released.
 
 	Args:
-		allow_mouse_click (bool, optional): Whether to return immediately on mouse clicks in
-			addition to key presses.
+		allow_mouse_click (bool, optional): Whether to return immediately on mouse
+			clicks in addition to key presses.
 	
 	"""
 	any_key_pressed = False
@@ -37,11 +42,11 @@ def any_key(allow_mouse_click=True):
 
 
 def key_pressed(key=None, queue=None):
-	"""Checks an event queue to see if a given key has been pressed.
+	"""Checks a given event queue for keypress events.
 	
-	If no key is specified, the function will return True if any key has been pressed. If an
-	event queue is not manually specified, :func:`~klibs.KLEventQueue.pump` will be called
-	and the returned event queue will be used.
+	If no key is specified, the function will return True if any key has been pressed.
+	If an event queue is not manually specified, this function will fetch and clear the
+	current contents of the input event queue.
 	
 	For a comprehensive list of valid key names, see the 'Name' column of the following 
 	table: https://wiki.libsdl.org/StuartPBentley/CombinedKeyTable
@@ -99,14 +104,14 @@ def mouse_clicked(button=None, released=False, within=None, queue=None):
 	this function will fetch and clear the current contents of the input event queue.
 
 	Args:
-		button (str, optional): The name of the button to check for clicks. Defaults to ``None``
-			(checks all buttons for clicks).
-		released (bool, optional): If True, this function will look for mouse button release
-			events instead of mouse button click events. Defaults to False.
-		within (:obj:`~klibs.KLBoundary.Boundary`, optional): A specific region of the screen to
-			check for clicks. Defaults to ``None`` (no boundary).
-		queue (:obj:`List` of :obj:`sdl2.SDL_Event`, optional): A list of events to check
-			for valid mouse button events.
+		button (str, optional): The name of the button to check for clicks. Defaults to
+			``None`` (checks all buttons for clicks).
+		released (bool, optional): If True, this function will look for mouse button
+			release events instead of mouse button click events. Defaults to False.
+		within (:obj:`~klibs.KLBoundary.Boundary`, optional): A specific region of the
+			screen to check for clicks. Defaults to ``None`` (no boundary).
+		queue (:obj:`List` of :obj:`sdl2.SDL_Event`, optional): A list of events to
+			check for valid mouse button events.
 
 	Returns:
 		bool: True if the button has been clicked, otherwise False.
@@ -235,6 +240,7 @@ def mouse_pos(pump_event_queue=True, position=None, return_button_state=False):
 		right pressed = 2, middle pressed = 3, none pressed = 0).
 
 	"""
+	# NOTE: Should really be split into 2 or 3 functions for UI simplicity
 	if pump_event_queue:
 		SDL_PumpEvents()
 	if not position:
@@ -279,6 +285,7 @@ def konami_code(callback=None, cb_args={}, queue=None):
 		bool: True if sequence was correctly entered, otherwise False.
 
 	"""
+	# TODO: Might actually be useful if you could specify a custom code (e.g. 123)
 	sequence = [
 		SDLK_UP, SDLK_DOWN, SDLK_UP, SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, SDLK_LEFT, SDLK_RIGHT,
 		SDLK_b, SDLK_a
@@ -378,13 +385,17 @@ def ui_request(key_press=None, execute=True, queue=None):
 
 
 def smart_sleep(interval, units=TK_MS):
-	"""Stops and waits for a given amount of time, ensuring that any 'quit' or 'calibrate' key
-	commands issued during the wait interval are processed.
+	"""Waits a given duration while still allowing for quit events.
+	s
+	This function is useful when you want your program to stop and wait
+	for an interval while still listening for quit events during that
+	period.
 
 	Args:
 		interval (float): The number of units of time to pause execution for.
-		units (int, optional): The time unit of 'interval', must be one of `klibs.TK_S` (seconds)
-			or `klibs.TK_MS` (milliseconds). Defaults to milliseconds.
+		units (int, optional): The time unit of 'interval', must be one of
+			`klibs.TK_S` (seconds) or `klibs.TK_MS` (milliseconds). Defaults
+			to milliseconds.
 			
 	"""
 	if units == TK_MS:

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -148,6 +148,54 @@ def mouse_clicked(button=None, released=False, within=None, queue=None):
 	return clicked
 
 
+def get_clicks(button=None, released=False, queue=None):
+	"""Gets the (x, y) pixel coordinates of any mouse clicks within the event queue.
+	
+	If a button is specified, this function will only return the pixel coordinates for
+	clicks of that button. Otherwise, this function will return click coordinates for
+	all buttons. Valid button names are ``'left'``, ``'right'``, and ``'middle'``.
+	
+ 	If an event queue is not provided, this function will fetch and clear the current
+	contents of the input event queue.
+
+	Args:
+		button (str, optional): The name of the button to check for clicks. Defaults to
+			``None`` (returns clicks from all buttons).
+		released (bool, optional): If True, this function will return the coordinates
+			for mouse button release events instead of mouse button click events.
+			Defaults to False.
+		queue (:obj:`List` of :obj:`sdl2.SDL_Event`, optional): A list of events to
+			checkfor valid mouse button events.
+
+	Returns:
+		:obj:`List`: A list containing the (x, y) coordinates of any matching mouse
+		click events.
+
+	Raises:
+		ValueError: If an invalid button name is provided.
+
+	"""
+	buttons = {
+		'left': SDL_BUTTON_LEFT, 'right': SDL_BUTTON_RIGHT, 'middle': SDL_BUTTON_MIDDLE,
+	}
+	if button:
+		if not button in buttons.keys():
+			raise ValueError("'{0}' is not a valid mouse button name.".format(button))
+		button = buttons[button]
+
+	clicks = []
+	if queue == None:
+		queue = pump(True)
+	for e in queue:
+		if e.type == SDL_KEYDOWN:
+			ui_request(e.key.keysym)
+		elif e.type == (SDL_MOUSEBUTTONUP if released else SDL_MOUSEBUTTONDOWN):
+			if not button or e.button.button == button:
+				clicks.append((e.button.x, e.button.y))
+
+	return clicks
+
+
 def show_cursor():
 	"""Shows the mouse cursor if it is currently hidden.
 

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -37,10 +37,11 @@ def any_key(allow_mouse_click=True):
 
 
 def key_pressed(key=None, queue=None):
-	"""Checks an event queue to see if a given key has been pressed. If no key is specified,
-	the function will return True if any key has been pressed. If an event queue is not
-	manually specified, :func:`~klibs.KLUtilities.pump` will be called and the returned event
-	queue will be used.
+	"""Checks an event queue to see if a given key has been pressed.
+	
+	If no key is specified, the function will return True if any key has been pressed. If an
+	event queue is not manually specified, :func:`~klibs.KLEventQueue.pump` will be called
+	and the returned event queue will be used.
 	
 	For a comprehensive list of valid key names, see the 'Name' column of the following 
 	table: https://wiki.libsdl.org/StuartPBentley/CombinedKeyTable
@@ -52,7 +53,7 @@ def key_pressed(key=None, queue=None):
 		key (str or :obj:`sdl2.SDL_Keycode`, optional): The key name or SDL keycode
 			corresponding to the key to check. If not specified, any keypress will return
 			True.
-		queue (:obj:`List` of :obj:`sdl2.SDL_Event`, optional): A list of SDL_Events to check
+		queue (:obj:`List` of :obj:`sdl2.SDL_Event`, optional): A list of events to check
 			for valid keypress events.
 
 	Returns:
@@ -265,15 +266,17 @@ def ui_request(key_press=None, execute=True, queue=None):
 	- Calibrate Eye Tracker (Ctrl/Command-C): Enter setup mode for the connected eye tracker, 
 	  if eye tracking is enabled for the experiment and not using TryLink simulation.
 	
-	If no event queue from :func:`~klibs.KLUtilities.pump` and no keypress event(s) are
+	If no event queue from :func:`~klibs.KLEventQueue.pump` and no keypress event(s) are
 	supplied to this function, the current contents of the SDL2 event queue will be fetched
-	and processed using :func:`~klibs.KLUtilities.pump`. 
+	and processed using :func:`~klibs.KLEventQueue.pump`. 
 	
 	This function is meant to be called during loops in your experiment where no other input
 	checking occurs, to ensure that you can quit your experiment or recalibrate your eye
-	tracker during those periods. This function is automatically called by other functions that
-	process keyboard/mouse input, such as :func:`any_key` and :func:`key_pressed`, so you will
-	not need to call it yourself in places where one of them is already being called. 
+	tracker during those periods.
+	
+	This function is called implicitly by other functions that process keyboard/mouse input, such
+	as :func:`any_key`, :func:`key_pressed`, and :func:`mouse_clicked` (but not :func:`mouse_pos`),
+	so you will not need to call it yourself in places where one of them is already being called. 
 	In addition, the :obj:`~klibs.KLResponseCollectors.ResponseCollector` collect method also
 	calls this function every loop, meaning that you do not need to include it when writing
 	ResponseCollector callbacks.

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -175,6 +175,7 @@ def konami_code(callback=None, cb_args={}, queue=None):
 	if not hasattr(konami_code, "input"):
 		konami_code.input = [] # static variable, stays with the function between calls
 	
+	code_entered = False
 	if queue == None:
 		queue = pump(True)
 	for e in queue:
@@ -184,11 +185,14 @@ def konami_code(callback=None, cb_args={}, queue=None):
 			if konami_code.input != sequence[:len(konami_code.input)]:
 				konami_code.input = [] # reset input if mismatch encountered
 			elif len(konami_code.input) == len(sequence):
-				konami_code.input = []
-				if callable(callback):
-					callback(**cb_args)
-				return True
-	return False
+				code_entered = True
+
+	if code_entered:
+		konami_code.input = []
+		if callable(callback):
+			callback(**cb_args)
+
+	return code_entered
 
 
 def ui_request(key_press=None, execute=True, queue=None):

--- a/klibs/tests/test_KLUserInterface.py
+++ b/klibs/tests/test_KLUserInterface.py
@@ -14,6 +14,8 @@ from eventfactory import click, keydown, keyup, queue_event
 # NOTE: missing tests for any_key and konami_code
 
 
+# Fixtures and helpers
+
 @pytest.fixture(scope='module')
 def with_sdl():
     sdl2.SDL_ClearError()
@@ -37,6 +39,7 @@ class UIRequestTester(object):
         self.command = 'calibrate'
 
 
+# Actual tests
 
 @pytest.mark.skip("not implemented")
 def test_any_key(with_sdl):
@@ -127,3 +130,26 @@ def test_ui_request(with_sdl):
     assert ui.ui_request(queue=[not_quit], execute=False) == False
     with pytest.raises(TypeError):
         ui.ui_request(normal_keys, queue=[])
+
+    
+def test_smart_sleep(with_sdl):
+
+    # Initialize fake experiment class in environment
+    from klibs import env
+    env.exp = UIRequestTester()
+
+    # Queue a quit event and see if smart_sleep catches it
+    queue_event(keydown('q', mod='ctrl'))
+    start = time.time()
+    ui.smart_sleep(1, units=TK_MS) # 1 millisecond
+    duration = time.time() - start
+    assert duration < 0.002
+    assert env.exp.command == 'quit'
+
+    # Test units of seconds
+    env.exp.command = None
+    start = time.time()
+    ui.smart_sleep(0.001, units=TK_S) # 1 millisecond
+    duration = time.time() - start
+    assert duration < 0.002
+    assert env.exp.command == None

--- a/klibs/tests/test_KLUserInterface.py
+++ b/klibs/tests/test_KLUserInterface.py
@@ -79,6 +79,49 @@ def test_key_pressed(with_sdl):
         ui.key_pressed('nope', queue=pressed_ab)
 
 
+def test_mouse_clicked(with_sdl):
+
+    # Initialize fake experiment class in environment
+    from klibs import env
+    env.exp = UIRequestTester()
+    
+    # Test basic functionality
+    test_clicks = [click('left'), click('middle'), click('right', release=True)]
+    assert ui.mouse_clicked(queue=test_clicks) == True
+    assert ui.mouse_clicked('left', queue=test_clicks) == True
+    assert ui.mouse_clicked('middle', queue=test_clicks) == True
+    assert ui.mouse_clicked('right', queue=test_clicks) == False
+    assert ui.mouse_clicked('left', released=True, queue=test_clicks) == False
+    assert ui.mouse_clicked('right', released=True, queue=test_clicks) == True
+
+    # Test with provided boundaries
+    test_clicks2 = [click('left'), click('left', loc=(200, 200))]
+    test_bounds = RectangleBoundary('test', (100, 100), (300, 300))
+    test_bounds2 = RectangleBoundary('test', (300, 300), (500, 500))
+    assert ui.mouse_clicked(within=test_bounds, queue=test_clicks2) == True
+    assert ui.mouse_clicked('left', within=test_bounds, queue=test_clicks2) == True
+    assert ui.mouse_clicked('left', within=test_bounds2, queue=test_clicks2) == False
+
+    # Test without providing queue as argument
+    queue_event(test_clicks[0])
+    assert ui.mouse_clicked('left') == True
+    assert ui.mouse_clicked('left') == False  # queue should be flushed after first call
+
+    # Test intercepting of ui request commands
+    quit_test = [click('left'), keydown('q', mod='ctrl')]
+    ui.mouse_clicked('left', queue=quit_test)
+    assert env.exp.command == 'quit'
+
+    # Test edge cases
+    assert ui.mouse_clicked(queue=[]) == False
+    assert ui.mouse_clicked('left', queue=[]) == False
+    assert ui.mouse_clicked('left', queue=[keyup('a')]) == False
+    with pytest.raises(ValueError):
+        ui.mouse_clicked('nope', queue=test_clicks)
+    with pytest.raises(TypeError):
+        ui.mouse_clicked(within=test_clicks, queue=test_clicks)
+
+
 @pytest.mark.skip("not implemented")
 def test_konami_code(with_sdl):
     pass


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR adds two new functions for handling user input and creating UIs in klibs:

* `mouse_clicked`: Checks an event queue for mouse click events (optionally specifying which button to listen for, whether to listen for mouse down or mouse up events, and which boundary (if any) to check for clicks within). Essentially a mouse-equivalent of `key_pressed`.

* `get_clicks`: Returns the (x, y) coordinates of any mouse clicks within a given event queue. Can optionally specify which mouse button to check for, and whether to return the coordinates of mouse down or mouse up events.

In addition, this PR contains some assorted docs cleanup and minor fixes for the KLUserInferface module.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
