### PR TITLE
Replace IndependentVariableSet API with FactorSet

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 This is a log of the latest changes and improvements to KLibs.
 
 
-0.7.6a2
+0.7.7b1
 -------
 
 Released on 2023-02-XX
@@ -22,6 +22,8 @@ New Features:
   add fonts with ``txtm.add_font``. For example, if ``ComicSans.ttf`` is present
   in the experiment's font folder, you can now create a custom font style with
   ``font = "ComicSans"`` without manually loading the font.
+* Added a new dict-based API, :obj:`~klibs.KLStructure.FactorSet`, for defining
+  the per-trial categorical factors and their levels for the experiment.
 * Added a ``released`` argument to :func:`~klibs.KLUserInterface.key_pressed`
   to optionally check for 'key released' events instead of 'key pressed' events.
 * Added a new method :meth:`~klibs.KLEventInterface.EventManager.add_event` for
@@ -31,6 +33,13 @@ New Features:
 
 
 Runtime Changes:
+* The way that trials are internally generated and randomized has been changed,
+  breaking random seed compatibility with older releases.
+* Previously, it was possible (albeit unlikely) for a block with more than
+  enough trials for a complete factor set (e.g. trial count of 24 for a factor
+  set of 16) to be missing one or more possible factor combinations. This has
+  now been fixed, as each block of trials is now generated individually (instead
+  of being generated all at once and then split into blocks).
 * The TryLink mouse-simulated eye tracker now supports performing drift correct
   by pressing the space bar in addition to clicking.
 * The EyeLink camera setup image is now always scaled to a height of 480 pixels
@@ -75,7 +84,7 @@ Fixed Bugs:
   rendered within the same message.
 
 
-0.7.6a1
+0.7.6b1
 -------
 
 Released on 2022-12-01.

--- a/klibs/KLIndependentVariable.py
+++ b/klibs/KLIndependentVariable.py
@@ -1,7 +1,7 @@
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
 from klibs.KLNamedObject import NamedInventory, NamedObject
-from klibs.KLUtilities import iterable
+from klibs.KLInternal import iterable
 
 
 class VariableValue(NamedObject):

--- a/klibs/KLInternal.py
+++ b/klibs/KLInternal.py
@@ -62,7 +62,7 @@ def iterable(obj, exclude_strings=True):
 
 	"""
 	if exclude_strings:
-		return hasattr(obj, '__iter__') and not isinstance(obj, str)
+		return hasattr(obj, "__iter__") and not hasattr(obj, "upper")
 	else:
 		try:
 			iter(obj)

--- a/klibs/KLStructure.py
+++ b/klibs/KLStructure.py
@@ -1,0 +1,103 @@
+import itertools
+from copy import deepcopy
+from collections import OrderedDict
+
+from klibs.KLInternal import iterable
+
+
+class FactorSet(object):
+    """A class representing the full set of factors for an experiment.
+
+    For example, a simple attention cueing paradigm might have 3 factors:
+    target location (left or right), cue validity (valid, invalid, or neutral),
+    and stimulus onset asynchrony (SOA, i.e. the time delay between the onset of
+    the cue and target stimului, in this case 200, 400, or 800 ms). Specifying
+    this structure in a FactorSet would look something like this::
+
+        factors = FactorSet({
+            'target_loc': ['left', 'right'],
+            'cue_validity': ['valid', 'invalid', 'neutral'],
+            'soa': [200, 400, 800],
+        })
+
+    This creates a set with 18 unique factor combinations (2 x 3 x 3 = 18) that
+    can be then used within KLibs.
+    
+    If placed in an experiment's [structure/idvars] file, trials will be randomly
+    generated 
+
+	Args:
+		factors (dict): A dictionary in the format ``{'factor': values}``,
+			specifying all possible levels of each factor in the set.
+
+	"""
+    def __init__(self, factors=None):
+        if factors is None:
+            factors = {}
+        self._factors = OrderedDict(deepcopy(factors))
+        
+    def _get_combinations(self):
+        # Generates a list of all unique factor combinations in the set
+        factor_names = list(self._factors.keys())
+        factor_levels = [self._factors[f] for f in factor_names]
+        factor_set = []
+        for combination in itertools.product(*factor_levels):
+            trial_dict = dict(zip(factor_names, combination))
+            factor_set.append(trial_dict)
+        return factor_set
+
+    def override(self, factor_mask):
+        """Creates a new copy of the factor set with a given set of overrides.
+
+        For example, if you wanted to define factor sets for a study where some
+        blocks have 50% cue validity and others have 66% cue validity, you could
+        do the following::
+
+            factors_50 =  FactorSet({
+                'target_loc': ['left', 'right'],
+                'cue_validity': ['valid', 'invalid'],
+                'soa': [200, 400, 800],
+            })
+
+            factors_66 = factors_50.override({
+                'cue_validity': ['valid', 'valid', 'invalid']
+            })
+
+        Note that all overrides must correspond to factors that currently exist
+        within the set: this method only allows for modifying the levels of
+        existing factors and does not allow for adding new factors.
+
+        Args:
+            factor_mask (dict): A dictionary in the form ``{'factor': values}``
+                specifying which factors to override and the new values with
+                which to override the existing factor levels.
+
+        Returns:
+            :obj:`FactorSet`: A new factor set with the given overrides applied.
+
+        Raises:
+            ValueError: If any factor in the override mask does not match the
+                name of an existing factor in the set.
+        
+        """
+        err = "'{0}' is not the name of a factor in the set."
+        new = deepcopy(self._factors)
+        for factor in factor_mask.keys():
+            if factor in self.names:
+                new_levels = factor_mask[factor]
+                if not iterable(new_levels):
+                    new_levels = [new_levels]
+                new[factor] = new_levels
+            else:
+                raise ValueError(err.format(factor))
+        return FactorSet(new)
+        
+    @property
+    def names(self):
+        """list: The names of all factors within the set."""
+        return list(self._factors.keys())
+
+    @property
+    def set_length(self):
+        """int: The number of trials required for the full factor set."""
+        return len(self._get_combinations())

--- a/klibs/KLStructure.py
+++ b/klibs/KLStructure.py
@@ -4,6 +4,12 @@ from collections import OrderedDict
 
 from klibs.KLInternal import iterable
 
+# TODO: Add tuple support to FactorSets for repeated factors (e.g. ('valid', 3))?
+# Could also create a custom class or function for this, e.g. rep('valid', 3),
+# so you can have tuples as factors (e.g. colours) without breaking things
+#  - Depends on whether having iterables as factor levels is a good or bad idea,
+#    so will need to think on it.
+
 
 class FactorSet(object):
     """A class representing the full set of factors for an experiment.
@@ -11,7 +17,7 @@ class FactorSet(object):
     For example, a simple attention cueing paradigm might have 3 factors:
     target location (left or right), cue validity (valid, invalid, or neutral),
     and stimulus onset asynchrony (SOA, i.e. the time delay between the onset of
-    the cue and target stimului, in this case 200, 400, or 800 ms). Specifying
+    the cue and target stimuli, in this case 200, 400, or 800 ms). Specifying
     this structure in a FactorSet would look something like this::
 
         factors = FactorSet({
@@ -22,9 +28,6 @@ class FactorSet(object):
 
     This creates a set with 18 unique factor combinations (2 x 3 x 3 = 18) that
     can be then used within KLibs.
-    
-    If placed in an experiment's [structure/idvars] file, trials will be randomly
-    generated 
 
 	Args:
 		factors (dict): A dictionary in the format ``{'factor': values}``,

--- a/klibs/KLTrialFactory.py
+++ b/klibs/KLTrialFactory.py
@@ -263,19 +263,3 @@ class TrialFactory(object):
 					trial_num += 1
 				block_num += 1
 				log_f.write("\n")
-
-
-	@property
-	def trial_generation_function(self, trial_generator):
-		"""Not properly implemented, unlikely to work. Still figuring out how/if custom
-		trial generation should be handled.
-		"""
-		return self.trial_generator
-
-
-	@trial_generation_function.setter
-	def trial_generation_function(self, trial_generator):
-		if not hasattr(trial_generator, '__call__'):
-			raise ValueError("trial_generator must be a function definition.")
-		else:
-			self.trial_generator = trial_generator

--- a/klibs/resources/template/independent_variables.py
+++ b/klibs/resources/template/independent_variables.py
@@ -42,6 +42,9 @@ factors defined in your FactorSet:
             self.cue_loc = self.right_loc
             self.target_loc = self.right_loc if valid_cue else self.left_loc
 
+If a level of a factor is repeated multiple times (e.g. 3 valid cues per invalid cue),
+you can also note this using a `(level, count)` tuple as shorthand, e.g. `('valid', 3)`.
+
 """
 
 exp_factors = FactorSet({

--- a/klibs/resources/template/independent_variables.py
+++ b/klibs/resources/template/independent_variables.py
@@ -1,69 +1,49 @@
-from klibs.KLIndependentVariable import IndependentVariableSet
+from klibs.KLStructure import FactorSet
 
-PROJECT_NAME_ind_vars = IndependentVariableSet()
+""" ##### FactorSet Tutorial #####
 
-"""
-*** SAMPLE CONFIGURATION - REMOVE AFTER FINISHING REAL CONFIG ***
+This file specifies the different trial factors and their levels for the experiment.
 
-First we create an IndependentVariableSet object that will group together all the independent variables the experiment
-will use, like so:
+For example, a spatial cueing task (where participants are cued to respond to targets
+on the left or right side of the screen) might have the following factors that change
+from trial to trial:
 
->> PROJECT_NAME_ind_vars = IndependentVariableSet()
+  1) The validity of the spatial cue (same or different location from target)
+  2) The location of the spatial cue (left or right of screen)
+  3) The onset delay between the cue and target (200, 400, or 800 ms)
+  4) The presence of an auditory alerting tone (present or absent)
 
-Then we create empty variables within this set. At this point we're not providing any values, just a name and a data
-type that will tell klibs that this variable exists and what pythonic data type it should expect that variable's values
-to hold. In this example we create four variables, one for each type.
+In addition to the above, let's say you want cues to be valid 66% of the time. To 
+specify this sort of factor structure, you can do something like this:
 
->> PROJECT_NAME_ind_vars.add_variable("color", str)
->> PROJECT_NAME_ind_vars.add_variable("size", float)
->> PROJECT_NAME_ind_vars.add_variable("active", bool)
->> PROJECT_NAME_ind_vars.add_variable("count", int)
+exp_factors = FactorSet({
+    'cue_validity': ['valid', 'valid', 'invalid'],
+    'cue_location': ['left', 'right'],
+    'target_onset': [200, 400, 800],
+    'alerting_tone': [True, False],
+})
 
-Finally, we add values to each variable. This can be done one at a time, as in the colors example below:
+When the experiment is launched, the FactorSet will be loaded by the klibs runtime and
+used to generate trials based on the full set of unique combinations of factors.
 
->> PROJECT_NAME_ind_vars['color'].add_value("blue")
->> PROJECT_NAME_ind_vars['color'].add_value("blue")
->> PROJECT_NAME_ind_vars['color'].add_value("blue")
+Specifically, the klibs runtime creates an attribute corresponding to each factor in the
+set within the Experiment (e.g. `self.cue_validity`, `self.target_onset`), and updates
+their values with their generated per-trial values on each trial. During `self.trial`
+and `self.trial_prep` you can use these values to write dynamic code based on the
+factors defined in your FactorSet:
 
-Or altogether in a comma-separated set, as in the 'count' example:
-
->> PROJECT_NAME_ind_vars['count'].add_values(1,2,3,4,5)
-
-Finally, values can have a distribution attached to them in case some values should feature more or less frequently, with
-respect to one and other, in the experiment. For example, if we wanted to have the 'size' variable be either 1.0 or 2.0
-occur more frequently than 5.0, we could add these values as such:
-
->> PROJECT_NAME_ind_vars['size'].add_value(1.0, 2)
->> PROJECT_NAME_ind_vars['size'].add_value(2.0, 2)
->> PROJECT_NAME_ind_vars['size'].add_value(5.0)
-
-Note that the there is no distribution value included for the third option. By default, every value has a distribution of
-1. You only need to set the distribution when it is larger than 1.
-
-Now, for every 5 trials that are generated from this IndependentVariableSet, only one of them will have 5.0 as the value
-of the 'size' independent variable.
-
-Adding distributions to values is also possible when adding values as a set by creating a tuple for each value, like so:
-
->> PROJECT_NAME_ind_vars['active'].add_values((True, 5), False)
-
-which is equivalent to:
-
->> PROJECT_NAME_ind_vars['active'].add_value(True, 5)
->> PROJECT_NAME_ind_vars['active'].add_value(False)
-
-As a final note, you may wish to selectively exclude certain values or even entire independent variables during development
-and testing. By default, all IndependentVariables and their values are enabled, but you can disable them by toggling their
-enabled parameter:
-
->> PROJECT_NAME_ind_vars['size'].enabled = False
-
-Now there will be no contribution for the 'size' independent variable during trial generation. Note that this independent
-variable will still exist at runtime (ie. the Experiment class will be able to reference 'self.size' but it's value will
-be None and will not change between trials.
-
-Similarly, individual values can also be disabled.
-
->> PROJECT_NAME_ind_vars['size'][1.0].enabled = False
+    self.trial_prep(self):
+        # Determine cue and target locations for the trial
+        valid_cue = self.cue_validity == "valid"
+        if self.cue_location == "left":
+            self.cue_loc = self.left_loc
+            self.target_loc = self.left_loc if valid_cue else self.right_loc
+        else:
+            self.cue_loc = self.right_loc
+            self.target_loc = self.right_loc if valid_cue else self.left_loc
 
 """
+
+exp_factors = FactorSet({
+    # Insert trial factors here
+})

--- a/klibs/tests/test_KLStructure.py
+++ b/klibs/tests/test_KLStructure.py
@@ -24,6 +24,20 @@ class TestFactorSet(object):
         assert len(tst.names) == 3
         assert 'cue_loc' in tst.names
 
+        # Test 'repeated level' shorthand
+        tst = FactorSet({
+            'target_loc': ['left', 'right'],
+            'cue_validity': [('valid', 3), 'invalid'],
+        })
+        assert tst.set_length == 8
+
+        # Test exception on invalid tuple input
+        with pytest.raises(RuntimeError):
+            tst = FactorSet({
+                'target_loc': ['left', 'right'],
+                'colour': [(0, 0, 0), (255, 255, 255)],
+            })
+
         # Test creating empty factor set
         tst = FactorSet({})
         assert tst._get_combinations() == [{}]
@@ -63,11 +77,20 @@ class TestFactorSet(object):
         assert tst2.names == tst.names
         assert len(tst2._factors['soa']) == 1
 
+        # Ensure original factor set wasn't modified
+        assert len(tst._factors['soa']) == 4
+
         # Test override with non-iterable
         tst3 = tst.override({'easy_trial': True})
         assert tst3.set_length == 12
         assert tst3.names == tst.names
         assert len(tst3._factors['easy_trial']) == 1
+
+        # Test override with repeated level tuple
+        tst4 = tst.override({'easy_trial': [True, (False, 2)]})
+        assert tst4.set_length == 36
+        assert tst4.names == tst.names
+        assert len(tst4._factors['easy_trial']) == 3
 
         # Test error on non-existant factor
         with pytest.raises(ValueError):

--- a/klibs/tests/test_KLStructure.py
+++ b/klibs/tests/test_KLStructure.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import pytest
+from collections import Counter
+
+from klibs.KLStructure import FactorSet
+
+
+class TestFactorSet(object):
+
+    def test_init(self):
+        # Test single factor
+        tst = FactorSet({'test': ['a', 'b']})
+        assert tst.set_length == 2
+        assert 'test' in tst.names
+
+        # Test multiple factors
+        tst = FactorSet({
+            'cue_loc': ['left', 'right', 'none'],
+            'easy_trial': [True, False],
+            'soa': [0, 200, 400, 800],
+        })
+        assert tst.set_length == 24
+        assert len(tst.names) == 3
+        assert 'cue_loc' in tst.names
+
+        # Test creating empty factor set
+        tst = FactorSet({})
+        assert tst._get_combinations() == [{}]
+        assert tst.set_length == 1
+
+    def test_get_combinations(self):
+        # Ensure factor set contains no duplicates
+        tst = FactorSet({
+            'cue_validity': ['valid', 'invalid', 'neutral'],
+            'easy_trial': [True, False],
+            'soa': [0, 200, 400, 800],
+        })
+        unique_combos = tst._get_combinations()
+        combo_counter = Counter([str(c) for c in unique_combos])
+        assert len(list(combo_counter.elements())) == 24
+        assert len(combo_counter.keys()) == 24
+
+        # Ensure factor set handles repeated levels correctly
+        tst = FactorSet({
+            'cue_validity': ['valid', 'valid', 'invalid'],
+            'easy_trial': [True, False],
+            'soa': [0, 200, 400, 800],
+        })
+        unique_combos = tst._get_combinations()
+        combo_counter = Counter([str(c) for c in unique_combos])
+        assert len(list(combo_counter.elements())) == 24
+        assert len(combo_counter.keys()) == 16
+
+    def test_override(self):
+        tst = FactorSet({
+            'cue_loc': ['left', 'right', 'none'],
+            'easy_trial': [True, False],
+            'soa': [0, 200, 400, 800],
+        })
+        tst2 = tst.override({'soa': [400]})
+        assert tst2.set_length == 6
+        assert tst2.names == tst.names
+        assert len(tst2._factors['soa']) == 1
+
+        # Test override with non-iterable
+        tst3 = tst.override({'easy_trial': True})
+        assert tst3.set_length == 12
+        assert tst3.names == tst.names
+        assert len(tst3._factors['easy_trial']) == 1
+
+        # Test error on non-existant factor
+        with pytest.raises(ValueError):
+            tst.override({'alerting_trial': [True, False]})

--- a/klibs/tests/test_KLStructure.py
+++ b/klibs/tests/test_KLStructure.py
@@ -3,6 +3,7 @@ import pytest
 from collections import Counter
 
 from klibs.KLStructure import FactorSet
+from klibs.KLTrialFactory import _generate_blocks
 
 
 class TestFactorSet(object):
@@ -71,3 +72,34 @@ class TestFactorSet(object):
         # Test error on non-existant factor
         with pytest.raises(ValueError):
             tst.override({'alerting_trial': [True, False]})
+
+
+def test_generate_blocks():
+    # Create a FactorSet and IndependentVariableSet for testing
+    tst = FactorSet({
+        'cue_loc': ['left', 'right', 'none'],
+        'easy_trial': [True, False],
+        'soa': [0, 200, 400, 800],
+    })
+
+    # Try generating a block of 20 trials
+    blocks = _generate_blocks(tst._factors, 1, 20)
+    assert len(blocks) == 1
+    assert len(blocks[0]) == 20
+    assert isinstance(blocks[0][0], dict)
+
+    # Try generating a block with the default factor set size
+    blocks = _generate_blocks(tst._factors, 1, 0)
+    assert len(blocks) == 1
+    assert len(blocks[0]) == 24
+
+    # Try generating a block an empty factor set
+    blocks = _generate_blocks({}, 1, 0)
+    assert len(blocks) == 1
+    assert len(blocks[0]) == 1
+    assert blocks[0][0] == {}
+
+    # Try generating multiple blocks
+    blocks = _generate_blocks({}, 4, 48)
+    assert len(blocks) == 4
+    assert all(len(b) == 48 for b in blocks)

--- a/klibs/tests/test_KLStructure.py
+++ b/klibs/tests/test_KLStructure.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+import sys
 import pytest
 import random
 from collections import Counter
 
 from klibs.KLStructure import FactorSet
 from klibs.KLTrialFactory import _generate_blocks
+
+is_python3 = sys.version_info[0] == 3
 
 
 class TestFactorSet(object):
@@ -129,8 +132,9 @@ def test_generate_blocks():
     assert all(len(b) == 48 for b in blocks)
 
     # Test whether random seed works as expected
-    random.seed(308053045)
-    block = _generate_blocks(tst._factors, 1, 20)[0]
-    assert block[0]['soa'] == 200 and block[0]['cue_loc'] == 'none'
-    assert block[1]['soa'] == 0 and block[1]['easy_trial'] == True
-    assert block[2]['soa'] == 800 and block[2]['cue_loc'] == 'right'
+    if is_python3:
+        random.seed(308053045)
+        block = _generate_blocks(tst._factors, 1, 20)[0]
+        assert block[0]['soa'] == 200 and block[0]['cue_loc'] == 'none'
+        assert block[1]['soa'] == 0 and block[1]['easy_trial'] == True
+        assert block[2]['soa'] == 800 and block[2]['cue_loc'] == 'right'

--- a/klibs/tests/test_KLStructure.py
+++ b/klibs/tests/test_KLStructure.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import random
 from collections import Counter
 
 from klibs.KLStructure import FactorSet
@@ -126,3 +127,10 @@ def test_generate_blocks():
     blocks = _generate_blocks({}, 4, 48)
     assert len(blocks) == 4
     assert all(len(b) == 48 for b in blocks)
+
+    # Test whether random seed works as expected
+    random.seed(308053045)
+    block = _generate_blocks(tst._factors, 1, 20)[0]
+    assert block[0]['soa'] == 200 and block[0]['cue_loc'] == 'none'
+    assert block[1]['soa'] == 0 and block[1]['easy_trial'] == True
+    assert block[2]['soa'] == 800 and block[2]['cue_loc'] == 'right'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_packages = ['klibs']
 
 setup(
 	name='KLibs',
-	version='0.7.6b1',
+	version='0.7.7b1',
 	description='A framework for building psychological experiments in Python',
 	author='Jonathan Mulle & Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR adds a new, friendly, dict-based method of specifying trial factors and factor levels in KLibs to replace IndependentVariableSet for new projects. Old projects using IndependentVariableSet will continue to work perfectly fine, but new projects will default to using FactorSet going forward.

This PR also lays the initial groundwork for the new (still WIP) KLStructure API for easily defining custom block/session structures.


# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
