### PR TITLE
Revise and improve EventManager

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Install dependencies for testing
         run: |
+          sudo apt-get install --fix-missing libgl1-mesa-dev
           python -m pip install --upgrade pip
           python -m pip install pytest mock
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -54,6 +54,8 @@ API Changes:
   ``add_event``.
 * Deprecated the ``pump_events`` options for ``before`` and ``after`` in
   :class:`~klibs.KLEventInferface.EventManger`.
+* Renamed :class:`~klibs.KLEventInferface.EventManger`'s ``start_clock`` and
+  ``stop_clock`` methods to ``start`` and ``reset``, respectively.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -58,6 +58,10 @@ API Changes:
   :class:`~klibs.KLEventInferface.EventManger`.
 * Renamed :class:`~klibs.KLEventInferface.EventManger`'s ``start_clock`` and
   ``stop_clock`` methods to ``start`` and ``reset``, respectively.
+* Removed the :class:`~klibs.KLEventInferface.EventManger` instance from
+  KLEnvironment and :class:`~klibs.KLEnvironment.EnvAgent`. The global
+  ``EventManager`` instance for the Experiment object (``self.evm``) is now a
+  regular attribute.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -26,6 +26,8 @@ New Features:
   to optionally check for 'key released' events instead of 'key pressed' events.
 * Added a new method :meth:`~klibs.KLEventInterface.EventManager.add_event` for
   a friendlier, more readable way of adding events to the trial sequencer.
+* Added a convenience function :func:`~klibs.KLTime.time_msec` for getting
+  timestamps in milliseconds.
 
 
 Runtime Changes:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -58,6 +58,9 @@ API Changes:
   :class:`~klibs.KLEventInferface.EventManger`.
 * Renamed :class:`~klibs.KLEventInferface.EventManger`'s ``start_clock`` and
   ``stop_clock`` methods to ``start`` and ``reset``, respectively.
+* Deprecated the ``trial_time`` and ``trial_time_ms`` attributes for
+  :class:`~klibs.KLEventInferface.EventManger`. Measuring durations within a
+  trial should be done with :mod:`~klibs.KLTime` functions/classes instead.
 * Removed the :class:`~klibs.KLEventInferface.EventManger` instance from
   KLEnvironment and :class:`~klibs.KLEnvironment.EnvAgent`. The global
   ``EventManager`` instance for the Experiment object (``self.evm``) is now a

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,6 +24,8 @@ New Features:
   ``font = "ComicSans"`` without manually loading the font.
 * Added a ``released`` argument to :func:`~klibs.KLUserInterface.key_pressed`
   to optionally check for 'key released' events instead of 'key pressed' events.
+* Added a new method :meth:`~klibs.KLEventInterface.EventManager.add_event` for
+  a friendlier, more readable way of adding events to the trial sequencer.
 
 
 Runtime Changes:
@@ -47,6 +49,9 @@ API Changes:
   returns the magnitude of measured drift error (in degrees).
 * Added a new parameter ``P.default_line_space`` for setting a custom
   default line spacing for text rendering (defaults to ``2.0``).
+* The ``register_ticket`` and ``register_tickets`` methods of
+  :class:`~klibs.KLEventInterface.EventManager` are now deprecated in favour of
+  ``add_event``.
 
 
 Fixed Bugs:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -52,6 +52,8 @@ API Changes:
 * The ``register_ticket`` and ``register_tickets`` methods of
   :class:`~klibs.KLEventInterface.EventManager` are now deprecated in favour of
   ``add_event``.
+* Deprecated the ``pump_events`` options for ``before`` and ``after`` in
+  :class:`~klibs.KLEventInferface.EventManger`.
 
 
 Fixed Bugs:

--- a/docs/source/api/eventinterface.rst
+++ b/docs/source/api/eventinterface.rst
@@ -1,6 +1,5 @@
 KLEventInterface
 ================
 
-.. automodule:: klibs.KLEventInterface
-	:undoc-members:
+.. autoclass:: klibs.KLEventInterface.EventManager
 	:members:

--- a/klibs/KLEnvironment.py
+++ b/klibs/KLEnvironment.py
@@ -7,7 +7,6 @@ by importing it from here.
 
 Attributes:
 	exp (:obj:`Experiment`): A pointer to the Experiment object of the current project.
-	evm (:obj:`EventManager`): The EventManager instance for the current KLibs session.
 	txtm (:obj:`TextManager`): The TextManager instance for the current project.
 	db (:obj:`DatabaseManager`): The connection to the current project's database.
 	el (:obj:`EyeLinkExt` or None): If 'P.eye_tracking' is True, this is the EyeLink (or TryLink)
@@ -16,7 +15,6 @@ Attributes:
 """
 
 exp = None  	# Experiment instance
-evm = None  	# EventManager instance
 txtm = None  	# TextManager instance
 db = None  		# DatabaseManager instance
 el = None  		# EyeLink instance
@@ -26,15 +24,6 @@ class EnvAgent(object):
 
 	def __init__(self):
 		object.__init__(self)
-
-	@property
-	def evm(self):
-		""":obj:`~klibs.KLEventInterface.EventManager`: The EventManager instance for the 
-		current KLibs runtime environment. 
-
-		"""
-		from klibs.KLEnvironment import evm
-		return evm
 
 	@property
 	def exp(self):

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -78,7 +78,8 @@ class EventManager(object):
 	Then, in the body of the experiment's :meth:`~.KLExperiment.trial` method, the EventManager can
 	then be used to watch for those events and change behaviour when they occur::
 
-		while self.evm.before('target_on', pump_events=True):
+		while self.evm.before('target_on'):
+			ui_request()
 			fill()
 			draw_stimuli()
 			if self.evm.between('cue_on', 'cue_off'):
@@ -148,38 +149,28 @@ class EventManager(object):
 
 
 	def before(self, label, pump_events=False):
-		"""Checks if the current trial time is before a given event.
-
-		.. warning:: Setting 'pump_events' to True will cause the input event queue to be cleared 
-		  every time the method is called. Please use :func:`~.pump` manually in loops where you
-		  will be processing user input.
+		"""Checks whether a given event has yet to occur in the trial.
 
 		Args:
-			label (str): The label of the event to check.
-			pump_events (bool, optional): If True, a :func:`~.ui_request` is performed when this
-				method is called. Defaults to False.
+			label (str): The name of the event to check.
+			pump_events (bool, optional): Deprecated, should always be False.
 
 		Returns:
-			True if the specified event has not yet occured within the trial, otherwise False.
+			True if the specified trial event has yet to occur, otherwise False.
 
 		"""
 		return not self.after(label, pump_events)
 
 
 	def after(self, label, pump_events=False):
-		"""Checks if the current trial time is after a given event.
-
-		.. warning:: Setting 'pump_events' to True will cause the input event queue to be cleared 
-		  every time the method is called. Please use :func:`~.pump` manually in loops where you
-		  will be processing user input.
+		"""Checks whether a given event has occurred in the trial.
 
 		Args:
-			label (str): The label of the event to check.
-			pump_events (bool, optional): If True, a :func:`~.ui_request` is performed when this
-				method is called. Defaults to False.
+			label (str): The name of the event to check.
+			pump_events (bool, optional): Deprecated, should always be False.
 
 		Returns:
-			True if the specified event has already occured within the trial, otherwise False.
+			True if the specified trial event has already occured, otherwise False.
 
 		"""
 		self._ensure_exists(label)
@@ -194,18 +185,18 @@ class EventManager(object):
 		return self.events[label].issued
 
 
-	def between(self, label_1, label_2):
-		"""Checks if the current trial time is between two given events.
+	def between(self, a, b):
+		"""Checks whether the current trial time is between two events.
 
 		Args:
-			label_1 (str): The label of the event to check if it is currently after.
-			label_2 (str): The label of the event to check if it is currently before.
+			a (str): The name of the first event.
+			b (str): The name of the second event.
 		
 		Returns:
-			True if the current trial time is between the specified events, otherwise False.
+			True if the trial time is between events a and b, otherwise False.
 
 		"""
-		return self.after(label_1) and self.before(label_2)
+		return self.after(a) and self.before(b)
 
 
 	def start_clock(self):

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -183,7 +183,7 @@ class EventManager(object):
 
 		# If event wasn't already issued, check if it should be issued now
 		if not self._issued[label]:
-			if self.events[label] < self.trial_time_ms:
+			if self.events[label] < self.time_elapsed:
 				self._issued[label] = True
 
 		return self._issued[label]
@@ -243,11 +243,20 @@ class EventManager(object):
 
 
 	@property
+	def time_elapsed(self):
+		# Internal method for getting time since start() in milliseconds.
+		if not self.start_time:
+			return 0.0
+		return (time() - self.start_time) * 1000
+
+
+	@property
 	def trial_time(self):
 		# Gets time since start() in seconds. Deprecated, not part of public API.
-		return 0.0 if self.start_time == None else (time() - self.start_time)
+		return self.time_elapsed / 1000.0
+
 
 	@property
 	def trial_time_ms(self):
-		# Gets time since start() in milliseconds. Not part of the public API.
-		return self.trial_time * 1000
+		# Alias for backwards compatibility, not part of the public API.
+		return self.time_elapsed

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -211,14 +211,10 @@ class EventManager(object):
 		built-in ``self.evm``, this is called automatically at the start of
 		every trial.
 
-		Raises:
-			RuntimeError: If this method is called while the trial clock is already running.
-
 		"""
-		if self.start_time != None:
-			err = "The EventManger trial clock cannot be started if it is already running."
-			raise RuntimeError(err)
 		self.start_time = time()
+		for label in self.events.keys():
+			self._issued[label] = False
 
 
 	def stop_clock(self):

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -222,6 +222,10 @@ class EventManager(object):
 	def reset(self):
 		"""Resets the EventManger, clearing all added events.
 
+		If you are using the :class:`~klibs.KLExperiment.Experiment` object's
+		built-in ``self.evm``, this is called automatically at the end of
+		every trial.
+
 		"""
 		self.events = {}
 		self._issued = {}
@@ -240,20 +244,10 @@ class EventManager(object):
 
 	@property
 	def trial_time(self):
-		"""float: Time in seconds since the start of the current trial.
-		
-		If called when the EventManager clock is not running (e.g. outside of a trial),
-		this will be equal to 0.
-		
-		"""
+		# Gets time since start() in seconds. Deprecated, not part of public API.
 		return 0.0 if self.start_time == None else (time() - self.start_time)
 
 	@property
 	def trial_time_ms(self):
-		"""float: Time in milliseconds since the start of the current trial.
-		
-		If called when the EventManager clock is not running (e.g. outside of a trial),
-		this will be equal to 0.
-		
-		"""
+		# Gets time since start() in milliseconds. Not part of the public API.
 		return self.trial_time * 1000

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -2,7 +2,6 @@
 __author__ = 'Jonathan Mulle & Austin Hurst'
 
 from klibs.KLConstants import TK_S, TK_MS
-from klibs import P
 from klibs.KLNamedObject import NamedObject
 from klibs.KLTime import precise_time as time
 from klibs.KLUserInterface import ui_request
@@ -55,6 +54,7 @@ class TrialEventTicket(NamedObject):
 		return self.__onset
 
 
+
 class EventManager(object):
 	"""A class for sequencing the events that will occur during a given trial, relative to the
 	trial onset.
@@ -103,16 +103,6 @@ class EventManager(object):
 		except KeyError:
 			err = "'{0}' does not match the name of any existing event."
 			raise ValueError(err)
-
-
-	def __event_issued(self, label):
-		if self.events[label].issued == True:
-			return True
-		elif self.events[label].onset < self.trial_time_ms:
-			self.events[label].issued = True
-			return True
-		else:
-			return False
 
 	
 	def register_ticket(self, event):
@@ -167,11 +157,7 @@ class EventManager(object):
 			True if the specified event has not yet occured within the trial, otherwise False.
 
 		"""
-		self._ensure_exists(label)
-		if pump_events:
-			ui_request()
-
-		return not self.__event_issued(label)
+		return not self.after(label, pump_events)
 
 
 	def after(self, label, pump_events=False):
@@ -194,7 +180,12 @@ class EventManager(object):
 		if pump_events:
 			ui_request()
 
-		return self.__event_issued(label)
+		# If event wasn't already issued, check if it should be issued now
+		if not self.events[label].issued:
+			if self.events[label].onset < self.trial_time_ms:
+				self.events[label].issued = True
+
+		return self.events[label].issued
 
 
 	def between(self, label_1, label_2):

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -102,41 +102,47 @@ class EventManager(object):
 			self.events[label]
 		except KeyError:
 			err = "'{0}' does not match the name of any existing event."
-			raise ValueError(err)
+			raise ValueError(err.format(label))
+
+
+	def add_event(self, label, onset, after=None):
+		"""Adds an event to the event manager.
+		
+		By default, the onsets of events are relative to the start of the trial
+		(e.g. a 'cue_on' event with an onset of 1000 will occur 1000 ms after the
+		trial begins). However, you can also define an event's onset as being
+		relative to another event's onset using the optional 'after' argument
+		(e.g. a 'cue_off' event occuring 100 ms after the 'cue_on' event).
+		
+		Args:
+			label (str): The name of the event to add (e.g. 'cue_on').
+			onset (int): The onset of the event (in milliseconds), relative to
+				the start of the trial (by default) or another event (if 'after'
+				is specified).
+			after (str, optional): The name of an existing event that the onset
+				is relative to. If not specified, the onset is relative to the
+				start of the trial.
+
+		"""
+		if after is not None:
+			# If 'after' provided, 'onset' is relative to that event
+			self._ensure_exists(after)
+			onset = self.events[after].onset + onset
+		self.events[label] = TrialEventTicket(label, onset)
 
 	
 	def register_ticket(self, event):
-		"""Registers an event with the EventManager for the upcoming trial.
-
-		If defining an event with a :obj:`List`, it must be in the format ``[label, onset]``, 
-		with 'label' being the name of the event and 'onset' being the time (in millseconds)
-		after trial start that the event occurs, such as::
-
-			self.evm.register_ticket(['target_on', 1000]) # 1000ms after trial start
-
-		Args:
-			event (:obj:`TrialEventTicket` or :obj:`List`): An event or List defining an
-				event to be registered with the EventManager.
-
-		"""
+		# Deprecated, use add_event instead
 		if not isinstance(event, TrialEventTicket):
 			try:
 				event = TrialEventTicket(*event)
 			except SyntaxError:
 				raise TypeError("Argument 'event' must be a List or a TrialEventTicket.")
-		self.events[event.label] = event
+		self.add_event(event.label, event.onset)
 
 
 	def register_tickets(self, events):
-		"""Registers multiple events with the EventManager for the upcoming trial.
-
-		See also: :meth:`register_ticket`
-
-		Args:
-			events (:obj:`List`): A List of :obj:`TrialEventTicket` or :obj:`List` objects
-				defining events to be registered with the EventManager. 
-
-		"""
+		# Deprecated, use add_event instead
 		for e in events:
 			self.register_ticket(e)
 

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -201,7 +201,7 @@ class EventManager(object):
 		return self.after(a) and self.before(b)
 
 
-	def start_clock(self):
+	def start(self):
 		"""Starts the EventManager's trial clock.
 		
 		The onsets of events added to the EventManager are relative to when this
@@ -217,13 +217,24 @@ class EventManager(object):
 			self._issued[label] = False
 
 
-	def stop_clock(self):
+	def reset(self):
 		"""Resets the EventManger, clearing all added events.
 
 		"""
 		self.events = {}
 		self._issued = {}
 		self.start_time = None
+
+	
+	def start_clock(self):
+		# Alias for backwards compatibility, will be removed soon
+		self.start()
+
+
+	def stop_clock(self):
+		# Alias for backwards compatibility, will be removed soon
+		self.reset()
+
 
 	@property
 	def trial_time(self):

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -11,6 +11,8 @@ class TrialEventTicket(NamedObject):
 	"""A ticket defining the name and onset time of an event that occurs within a trial. For use
 	with the :obj:`EventManager` class.
 
+	Deprecated, do not use.
+
 	Args:
 		label (:obj:`str`): The identfying name of the trial event (e.g. 'cue on').
 		onset (int or float): The onset time of the event, relative to the start of the trial.

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -95,6 +95,16 @@ class EventManager(object):
 		self.start_time = None
 
 
+	def _ensure_exists(self, label):
+		# Makes sure a given event exists in the manager, raising an exception
+		# if it doesn't
+		try:
+			self.events[label]
+		except KeyError:
+			err = "'{0}' does not match the name of any existing event."
+			raise ValueError(err)
+
+
 	def __event_issued(self, label):
 		if self.events[label].issued == True:
 			return True
@@ -141,19 +151,6 @@ class EventManager(object):
 			self.register_ticket(e)
 
 
-	def registered(self, label):
-		"""Checks if an event with a given name is currently registered with the EventManager.
-
-		Args:
-			label (str): The label of the event to check the registration of.
-
-		Returns:
-			True if the event is registered with the EventManager, otherwise False.
-
-		"""
-		return label in self.events
-
-
 	def before(self, label, pump_events=False):
 		"""Checks if the current trial time is before a given event.
 
@@ -170,10 +167,7 @@ class EventManager(object):
 			True if the specified event has not yet occured within the trial, otherwise False.
 
 		"""
-		if type(label) is not str:
-			raise ValueError("Expected 'str' for argument label; got {0}.".format(type(label)))
-		if not self.registered(label):
-			raise NameError("Event '{0}' not registered with the EventManager.".format(label))
+		self._ensure_exists(label)
 		if pump_events:
 			ui_request()
 
@@ -196,10 +190,7 @@ class EventManager(object):
 			True if the specified event has already occured within the trial, otherwise False.
 
 		"""
-		if type(label) is not str:
-			raise ValueError("Expected 'str' for argument label; got {0}.".format(type(label)))
-		if not self.registered(label):
-			raise NameError("Event '{0}' not registered with the EventManager.".format(label))
+		self._ensure_exists(label)
 		if pump_events:
 			ui_request()
 

--- a/klibs/KLEventInterface.py
+++ b/klibs/KLEventInterface.py
@@ -93,6 +93,7 @@ class EventManager(object):
 	def __init__(self):
 		super(EventManager, self).__init__()
 		self.events = {}
+		self._issued = {}
 		self.start_time = None
 
 
@@ -128,8 +129,9 @@ class EventManager(object):
 		if after is not None:
 			# If 'after' provided, 'onset' is relative to that event
 			self._ensure_exists(after)
-			onset = self.events[after].onset + onset
-		self.events[label] = TrialEventTicket(label, onset)
+			onset = self.events[after] + onset
+		self.events[label] = onset
+		self._issued[label] = False
 
 	
 	def register_ticket(self, event):
@@ -178,11 +180,11 @@ class EventManager(object):
 			ui_request()
 
 		# If event wasn't already issued, check if it should be issued now
-		if not self.events[label].issued:
-			if self.events[label].onset < self.trial_time_ms:
-				self.events[label].issued = True
+		if not self._issued[label]:
+			if self.events[label] < self.trial_time_ms:
+				self._issued[label] = True
 
-		return self.events[label].issued
+		return self._issued[label]
 
 
 	def between(self, a, b):
@@ -224,6 +226,7 @@ class EventManager(object):
 
 		"""
 		self.events = {}
+		self._issued = {}
 		self.start_time = None
 
 	@property

--- a/klibs/KLExperiment.py
+++ b/klibs/KLExperiment.py
@@ -19,6 +19,7 @@ class Experiment(EnvAgent):
 	paused = False
 
 	def __init__(self):
+		from klibs.KLEventInterface import EventManager
 		from klibs.KLAudio import AudioManager
 		from klibs.KLResponseCollectors import ResponseCollector
 		from klibs.KLTrialFactory import TrialFactory
@@ -31,7 +32,8 @@ class Experiment(EnvAgent):
 
 		self.audio = AudioManager() # initialize audio management for the experiment
 		self.rc = ResponseCollector() # add default response collector
-		self.database = self.db # use database from evm
+		self.database = self.db # use database from env
+		self._evm = EventManager()
 
 		self.trial_factory = TrialFactory()
 		if P.manual_trial_generation is False:
@@ -337,3 +339,15 @@ class Experiment(EnvAgent):
 			blit(logo, 5, P.screen_c)
 			flip()
 		any_key()
+
+
+	@property
+	def evm(self):
+		""":obj:`~klibs.KLEventInterface.EventManager`: The trial event sequencer for
+		the experiment.
+
+		Is automatically started just prior to running :meth:`trial`, and automatically
+		reset when each trial ends.
+
+		"""
+		return self._evm

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 import aggdraw
 from sdl2 import SDL_GetKeyFromName, SDL_KEYDOWN, SDL_KEYUP, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP
 
-from klibs.KLEnvironment import EnvAgent, evm
+from klibs.KLEnvironment import EnvAgent
 from klibs.KLExceptions import BoundaryError
 from klibs.KLNamedObject import NamedObject
 from klibs.KLConstants import (RC_AUDIO, RC_COLORSELECT, RC_DRAW, RC_KEYPRESS,
@@ -277,6 +277,11 @@ class ResponseListener(NamedObject, EnvAgent):
 		
 		"""
 		return self.__eyetracking
+	
+	@property
+	def evm(self):
+		# Awful hack, but needed to avoid breaking CAST for now
+		return self.exp.evm
 
 
 class KeyPressResponse(ResponseListener):
@@ -1210,7 +1215,7 @@ class ResponseCollector(EnvAgent):
 			self.after_flip_callback(*self.after_flip_args, **self.after_flip_kwargs)
 		
 		# Set collection start time for calculating RTs later, enter collection loop
-		self.rc_start_time = self.evm.trial_time_ms
+		self.rc_start_time = self.exp.evm.trial_time_ms
 		for l in self.using():
 			self.listeners[l]._rc_start = self.rc_start_time
 		self.__collect()
@@ -1235,10 +1240,10 @@ class ResponseCollector(EnvAgent):
 
 			# Check if response collection has timed out or end collection event has occurred
 			if self.end_collection_event:
-				if self.evm.after(self.end_collection_event):
+				if self.exp.evm.after(self.end_collection_event):
 					break
 			else:
-				t = self.evm.trial_time_ms
+				t = self.exp.evm.trial_time_ms
 				timeout = self.terminate_after[0]
 				if self.terminate_after[1] == TK_S: timeout *= 1000.0
 				if t > (self.rc_start_time + timeout):

--- a/klibs/KLTime.py
+++ b/klibs/KLTime.py
@@ -3,16 +3,21 @@ __author__ = 'Jonathan Mulle & Austin Hurst'
 
 from sdl2 import SDL_GetPerformanceCounter, SDL_GetPerformanceFrequency
 
+# TODO: Clean up the docs and code here
+
 
 def precise_time():
-    """Returns the current time in seconds since an arbitrary past point in time. The time
-    returned is independent of the system's clock, so it won't be disrupted by network clock
-    synchronization, daylight savings time, or anything else. Should be used instead of
-    Python's time.time() when precision is more important than getting a unique value that
-    can be converted back to real-world time.
+    """Returns the time (in seconds) since the task was launched.
+	
+	The time returned has sub-millisecond precision and is independent of the
+	system's clock, so it won't be disrupted by things like network clock
+	synchronization or daylight savings time.
+	
+	Should be used instead of Python's ``time.time()`` when precision is more
+	important than getting a value that can be converted to real-world time.
 
     Returns:
-        float: Seconds since an arbitrary past point in time.
+        float: Seconds since the task was launched.
 
     """
     try:
@@ -20,6 +25,18 @@ def precise_time():
     except AttributeError:
         precise_time.freq = float(SDL_GetPerformanceFrequency())
         return SDL_GetPerformanceCounter() / precise_time.freq
+
+
+def time_msec():
+	"""Returns the time (in milliseconds) since the task was launched.
+
+	See :func:`precise_time` for more info.
+
+    Returns:
+        float: Milliseconds since the task was launched.
+
+	"""
+	return precise_time() * 1000
 
 
 class CountDown(object):

--- a/klibs/KLTime.py
+++ b/klibs/KLTime.py
@@ -76,7 +76,7 @@ class CountDown(object):
 		if self.paused:
 			return False
 		else:
-			return self.remaining() != 0
+			return self.remaining() > 0
 
 	def reset(self, start=True):
 		"""Resets the countdown so it starts back at the original duration.
@@ -160,7 +160,7 @@ class CountDown(object):
 
 	@property
 	def started(self):
-		return self.__started is not 0
+		return self.__started != 0
 
 	@property
 	def paused(self):
@@ -275,7 +275,7 @@ class Stopwatch(object):
 
 	@property
 	def started(self):
-		return self.__started is not 0
+		return self.__started != 0
 
 	@property
 	def paused(self):

--- a/klibs/cli.py
+++ b/klibs/cli.py
@@ -349,7 +349,6 @@ def run(screen_size, path, condition, devmode, no_tracker, seed):
 	env.db = DatabaseManager(
 		P.database_path, P.database_local_path if P.multi_user else None
 	)
-	env.evm = EventManager()
 
 	try:
 		# create basic text styles, load in user queries, and initialize slack (if enabled)

--- a/klibs/tests/test_KLEventInterface.py
+++ b/klibs/tests/test_KLEventInterface.py
@@ -1,0 +1,85 @@
+import pytest
+import mock
+
+from klibs.KLEventInterface import EventManager, TrialEventTicket
+
+
+time_tmp = 1
+
+def mock_time():
+    return time_tmp
+
+def add_time(secs):
+    global time_tmp
+    time_tmp += secs
+
+
+@pytest.fixture
+def evm():
+    events = EventManager()
+    events.register_ticket(['cue_on', 1000])
+    events.register_ticket(['cue_off', 1100])
+    events.register_ticket(['target_on', 1500])
+    return events
+
+
+
+class TestEventManager(object):
+
+    def test_register_ticket(self):
+        evm = EventManager()
+        # Add ticket as list
+        evm.register_ticket(['cue_on', 1000])
+        # Add ticket as TrialEventTicket
+        evm.register_ticket(TrialEventTicket('cue_off', 1100))
+        # Add multiple tickets at once
+        evm.register_tickets([
+            ['target_on', 1500], ['target_off', 1700]
+        ])
+        # Ensure all events were added correctly
+        assert 'cue_on' in evm.events.keys()
+        assert 'cue_off' in evm.events.keys()
+        assert 'target_on' in evm.events.keys()
+        assert 'target_off' in evm.events.keys()
+
+    def test_start_stop(self, evm):
+        evm.start_clock()
+        with pytest.raises(RuntimeError):
+            evm.start_clock()
+        evm.stop_clock()
+        evm.start_clock()
+        evm.stop_clock()
+
+    def test_trial_time(self, evm):
+        with mock.patch("klibs.KLEventInterface.time", wraps=mock_time):
+            evm.start_clock()
+            add_time(1.5)
+            assert evm.trial_time == 1.5
+            assert evm.trial_time_ms == 1500
+            add_time(0.5)
+            assert evm.trial_time == 2.0
+            assert evm.trial_time_ms == 2000
+            evm.stop_clock()
+
+    def test_before_after(self, evm):
+        # Test sequencing of trial events
+        with mock.patch("klibs.KLEventInterface.time", wraps=mock_time):
+            evm.start_clock()
+            assert evm.before('cue_on')
+            assert not evm.after('cue_on')
+            # Move forward by 1050 ms
+            add_time(1.05)
+            assert evm.after('cue_on')
+            assert evm.before('cue_off')
+            # Move forward another 200 ms
+            add_time(0.2)
+            assert evm.between('cue_off', 'target_on')
+            # Move forward 1000 ms
+            add_time(1.0)
+            assert evm.after('target_on')
+        # Test exceptions on bad input
+        with pytest.raises(ValueError):
+            assert evm.before('not_an_event')
+        with pytest.raises(ValueError):
+            assert evm.after('not_an_event')
+        evm.stop_clock()

--- a/klibs/tests/test_KLEventInterface.py
+++ b/klibs/tests/test_KLEventInterface.py
@@ -17,14 +17,29 @@ def add_time(secs):
 @pytest.fixture
 def evm():
     events = EventManager()
-    events.register_ticket(['cue_on', 1000])
-    events.register_ticket(['cue_off', 1100])
-    events.register_ticket(['target_on', 1500])
+    events.add_event('cue_on', 1000)
+    events.add_event('cue_off', 1100)
+    events.add_event('target_on', 1500)
     return events
 
 
 
 class TestEventManager(object):
+
+    def test_add_event(self):
+        evm = EventManager()
+        evm.add_event('cue_on', 1000)
+        evm.add_event('cue_off', 100, after='cue_on')
+        evm.add_event('target_on', 1500)
+        evm.add_event('target_off', 200, after='target_on')
+        # Ensure all events were added correctly
+        assert evm.events['cue_on'].onset == 1000
+        assert evm.events['cue_off'].onset == 1100
+        assert evm.events['target_on'].onset == 1500
+        assert evm.events['target_off'].onset == 1700
+        # Test exception on bad relative event name
+        with pytest.raises(ValueError):
+            evm.add_event('sound_off', 100, after='sound_on')
 
     def test_register_ticket(self):
         evm = EventManager()

--- a/klibs/tests/test_KLEventInterface.py
+++ b/klibs/tests/test_KLEventInterface.py
@@ -57,23 +57,23 @@ class TestEventManager(object):
         assert evm.events['target_on'] == 1500
         assert evm.events['target_off'] == 1700
 
-    def test_start_stop(self, evm):
-        evm.start_clock()
-        evm.start_clock()
-        evm.stop_clock()
+    def test_start_reset(self, evm):
+        evm.start()
+        evm.start()
+        evm.reset()
         evm.start_clock()
         evm.stop_clock()
 
     def test_trial_time(self, evm):
         with mock.patch("klibs.KLEventInterface.time", wraps=mock_time):
-            evm.start_clock()
+            evm.start()
             add_time(1.5)
             assert evm.trial_time == 1.5
             assert evm.trial_time_ms == 1500
             add_time(0.5)
             assert evm.trial_time == 2.0
             assert evm.trial_time_ms == 2000
-            evm.stop_clock()
+            evm.reset()
 
     def test_before_after(self, evm):
         # Test sequencing of trial events
@@ -96,4 +96,3 @@ class TestEventManager(object):
             assert evm.before('not_an_event')
         with pytest.raises(ValueError):
             assert evm.after('not_an_event')
-        evm.stop_clock()

--- a/klibs/tests/test_KLEventInterface.py
+++ b/klibs/tests/test_KLEventInterface.py
@@ -59,8 +59,7 @@ class TestEventManager(object):
 
     def test_start_stop(self, evm):
         evm.start_clock()
-        with pytest.raises(RuntimeError):
-            evm.start_clock()
+        evm.start_clock()
         evm.stop_clock()
         evm.start_clock()
         evm.stop_clock()

--- a/klibs/tests/test_KLEventInterface.py
+++ b/klibs/tests/test_KLEventInterface.py
@@ -33,10 +33,10 @@ class TestEventManager(object):
         evm.add_event('target_on', 1500)
         evm.add_event('target_off', 200, after='target_on')
         # Ensure all events were added correctly
-        assert evm.events['cue_on'].onset == 1000
-        assert evm.events['cue_off'].onset == 1100
-        assert evm.events['target_on'].onset == 1500
-        assert evm.events['target_off'].onset == 1700
+        assert evm.events['cue_on'] == 1000
+        assert evm.events['cue_off'] == 1100
+        assert evm.events['target_on'] == 1500
+        assert evm.events['target_off'] == 1700
         # Test exception on bad relative event name
         with pytest.raises(ValueError):
             evm.add_event('sound_off', 100, after='sound_on')
@@ -52,10 +52,10 @@ class TestEventManager(object):
             ['target_on', 1500], ['target_off', 1700]
         ])
         # Ensure all events were added correctly
-        assert 'cue_on' in evm.events.keys()
-        assert 'cue_off' in evm.events.keys()
-        assert 'target_on' in evm.events.keys()
-        assert 'target_off' in evm.events.keys()
+        assert evm.events['cue_on'] == 1000
+        assert evm.events['cue_off'] == 1100
+        assert evm.events['target_on'] == 1500
+        assert evm.events['target_off'] == 1700
 
     def test_start_stop(self, evm):
         evm.start_clock()


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR cleans up the interface for the EventManager class, adding a new friendly `add_event` method and deprecating `TrialEventTicket` and `register_ticket`. The `start_clock` and `stop_clock` methods have also been renamed to `start` and `reset`, respectively. The docs have also been heavily revised for clarity.

Basically, this rewrites the `EventManager` class so that it's simpler and more useful/understandable as a stand-alone class. It's more-or-less what I'd write for an event manager class if I started fresh, except for methods/aliases keeping compatibility with existing code. Unit tests have also been added for the `EventManager` class to ensure nothing obvious was broken by the cleanup and revisions here.

Minor fixes/cleanup to the KLTime module have been made here as well.

Added:
* `EventManager.add_event`
* `EventManager.start`
* `EventManager.reset`
* `EventManager.time_elapsed`
* `KLTime.time_msec`
* Unit tests for `EventManager`

Deprecated:
* `TrialEventTicket`
* `EventManager.register_ticket`
* `EventManager.register_tickets`
* `EventManager.start_clock`
* `EventManager.stop_clock`
* `EventManager.trial_time`
* `EventManager.trial_time_ms`

Removed:
* `EventManager.registered`
* `KLEnvironment.evm`
* `EnvAgent.evm`

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
