### PR TITLE
Add KLResponseListener module

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -11,6 +11,10 @@ Released on 2023-02-XX
 
 New Features:
 
+* Added a new module, :mod:`~klibs.KLResponseListeners`, to replace the
+  ``ResponseCollector`` API for a much simpler and more Pythonic way of
+  collecting common response types. The ``KLResponseCollector`` module is now
+  deprecated and should not be used for future projects.
 * Added :obj:`~klibs.KLText.TextStyle` to the public API, allowing easy
   on-the-fly definitions of new custom text styles as objects.
 * Added a new function :func:`~klibs.KLText.add_text_style` for defining new

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -44,6 +44,9 @@ Runtime Changes:
   by pressing the space bar in addition to clicking.
 * The EyeLink camera setup image is now always scaled to a height of 480 pixels
   for a larger view and easier setup.
+* Changed :func:`~klibs.KLUserInterface.any_key` to flush existing input before
+  starting and require that the mouse be both clicked `and` released before
+  returning to avoid registering spurious input.
 
 
 API Changes:

--- a/docs/source/api/key_map.rst
+++ b/docs/source/api/key_map.rst
@@ -1,6 +1,0 @@
-KLKeyMap
-========
-
-.. automodule:: klibs.KLKeyMap
-	:undoc-members:
-	:members:

--- a/docs/source/api/response_collectors.rst
+++ b/docs/source/api/response_collectors.rst
@@ -1,6 +1,0 @@
-KLResponseCollectors
-====================
-
-.. automodule:: klibs.KLResponseCollectors
-	:undoc-members:
-	:members:

--- a/docs/source/api/response_listeners.rst
+++ b/docs/source/api/response_listeners.rst
@@ -1,0 +1,5 @@
+KLResponseListener
+==================
+
+.. automodule:: klibs.KLResponseListeners
+	:members:

--- a/klibs/KLResponseCollectors.py
+++ b/klibs/KLResponseCollectors.py
@@ -22,8 +22,7 @@ from klibs.KLGraphics.utils import aggdraw_to_array
 from klibs.KLGraphics.KLDraw import Annulus, ColorWheel, Drawbject
 from klibs.KLAudio import PYAUDIO_AVAILABLE
 
-# TODO: Add a callback that's called during collection that can end collection early
-#       (e.g. for checking if gaze leaves fixation during response period)
+# NOTE: This module is deprecated, KLResponseListeners should be used for all future projects
 
 
 class Response(namedtuple('Response', ['value', 'rt'])):
@@ -950,6 +949,9 @@ class DrawResponse(ResponseListener, BoundarySet):
 class ResponseCollector(EnvAgent):
     """A container class used for collecting responses from one or more :class:`ResponseListener`
     types.
+
+    .. NOTE:: This class has been deprecated in favour of the listener classes in
+              KLResponseListener.
 
     Args:
         uses (:obj:`List` of :class:`ResponseListener` classes, optional): A list specifying the

--- a/klibs/KLResponseListeners.py
+++ b/klibs/KLResponseListeners.py
@@ -8,7 +8,7 @@ built-in ResponseListener types:
 * :class:`MouseButtonListener` - For collecting mouse button responses
 * :class:`ColorWheelListener` - For collecting color wheel judgement responses
 
-Additionally, it is relatively easy to define your own by creating a subclass of
+Additionally, you can create your own ResponseListener by creating a subclass of
 :class:`BaseResponseListener`.
 
 
@@ -113,9 +113,6 @@ from klibs.KLUserInterface import ui_request, mouse_pos
 from klibs.KLBoundary import AnnulusBoundary
 from klibs.KLUtilities import angle_between
 
-# TODO: Add some sort of tests for elapsed, collect, timeout, callback?
-# TODO: Update changelog
-
 
 class BaseResponseListener(object):
     """An abstract base class for creating response listeners.
@@ -162,8 +159,8 @@ class BaseResponseListener(object):
                     break
             # Fetch event queue and check for valid responses
             events = pump()
-            ui_request(queue=events)
             resp = self.listen(events)
+            ui_request(queue=events)
             # If a callback is provided, call it once per loop
             if not resp and self._callback:
                 interrupt = self._callback()

--- a/klibs/KLResponseListeners.py
+++ b/klibs/KLResponseListeners.py
@@ -216,7 +216,7 @@ class KeypressListener(BaseResponseListener):
             response.
         
         """
-        super(KeypressListener, self).collect()
+        return super(KeypressListener, self).collect()
 
     def listen(self, q):
         """Checks a queue of input events for valid keypress responses.

--- a/klibs/KLResponseListeners.py
+++ b/klibs/KLResponseListeners.py
@@ -43,8 +43,9 @@ class BaseResponseListener(object):
         self.init()
         while not resp:
             # End collection if the loop has timed out
-            if self.timed_out:
-                break
+            if self.timeout_ms:
+                if self.elapsed > self.timeout_ms:
+                    break
             # Fetch event queue and check for valid responses
             events = pump()
             ui_request(queue=events)
@@ -123,22 +124,13 @@ class BaseResponseListener(object):
     def elapsed(self):
         """float: The elapsed time (in ms) since response collection began.
 
-        If the listener's collection loop has not started yet, the elapsed time
-        will be 0.
+        If the listener's collection loop has ended or not started yet, the
+        elapsed time will be 0.
 
         """
         if not self._loop_start:
             return 0.0
         return (self._timestamp() - self._loop_start)
-
-    @property
-    def timed_out(self):
-        """bool: Whether the current response collection loop has timed out.
-
-        """
-        if not self.timeout_ms:
-            return False
-        return self.elapsed > self.timeout_ms
 
 
 

--- a/klibs/KLResponseListeners.py
+++ b/klibs/KLResponseListeners.py
@@ -1,0 +1,234 @@
+import sdl2
+
+from klibs.KLTime import precise_time
+from klibs.KLEventQueue import pump, flush
+from klibs.KLUserInterface import ui_request
+from klibs.KLResponseCollectors import Response
+
+# NOTE: Do away with Response class and just return two-item (value, rt) tuple?
+
+class BaseResponseListener(object):
+    """An abstract base class for creating response listeners.
+    
+    The purpose of ResponseListeners is to make it easy to collect responses of a
+    given type from participants (e.g. keypress responses, mouse cursor responses).
+    There are a number of built-in ResponseListener classes for common use cases, but
+    this base class is provided so that you can create your own.
+
+    For accurate response timing, the stimuli that the participant responds to (e.g.
+    a target in a cueing task) needs to be draw to the screen immediately before the
+    collection loop starts. This is because it takes a few milliseconds (usually ~17)
+    to refresh the screen, so you want to mark the start of the response period as
+    immediately after the participant sees the stimuli.
+
+    Args:
+        timeout (float, optional): The maximum duration (in seconds) to wait for a
+            valid response.
+
+    """
+    def __init__(self, timeout=None):
+        self._loop_start = None
+        self.timeout_ms = timeout * 1000 if timeout else None
+
+    def _timestamp(self):
+        # The timestamp (in milliseconds) to use as the start time for the loop.
+        return precise_time() * 1000
+
+    def collect(self):
+        """Collects a single response from the participant.
+        
+        """
+        resp = None
+        self.init()
+        while not resp:
+            # Check if the collection loop has timed out
+            if self.timeout_ms:
+                if (self._timestamp() - self._loop_start) > self.timeout_ms:
+                    break
+            # Fetch event queue and check for valid responses
+            events = pump()
+            ui_request(queue=events)
+            resp = self.listen(events)
+        self.cleanup()
+        # If no response given, return default response
+        if not resp:
+            resp = Response(None, -1)
+        return resp
+
+    def init(self):
+        """Initializes the listener for response collection.
+
+        This method prepares the listener to enter its collection loop, initializing
+        any necessary objects or hardware and setting the timestamp for when the
+        collection loop started.
+        
+        This only needs to be called manually if using :meth:`listen` directly in a
+        custom collection loop: otherwise, it is called internally by :meth:`collect`.
+
+        """
+        self._loop_start = self._timestamp()
+        flush()
+
+    def listen(self, q):
+        """Checks a queue of input events for valid responses.
+
+        This method checks a list of input events for valid responses, and
+        returns the value and reaction time of the response if one has occured.
+        It is the main method that needs to be defined when creating a custom
+        ResponseListener.
+        
+        This method is used internally by :meth:`collect`, but can also be used
+        directly to create custom response collection loops (along with
+        :meth:`init` and :meth:`cleanup`) in cases where :meth:`collect` doesn't
+        offer enough flexibility, e.g.::
+
+            response = None
+
+            listener.init()
+            while not response:
+                q = pump()
+                ui_request(queue=q)
+                response = listener.listen(q)
+
+            listener.cleanup()
+
+        Args:
+            q (list): A list of input events to check for valid responses.
+
+        Returns:
+            :obj:`klibs.KLResponseCollector.Response` or None: A Response object
+            containing the value and reaction time (in milliseconds) of the
+            response, or None if no response has been made.
+        
+        """
+        e = "ResponseListener subclass has no defined 'listen' method."
+        raise NotImplementedError(e)
+
+    def cleanup(self):
+        """Performs any necessary cleanup after response collection.
+
+        This method is the inverse of the :meth:`init` method, resetting any
+        initialized hardware or configured options to their original states. For
+        example, if collecting an audio response from a microphone and `init` opens
+        an audio stream for the device, this method would close it again after a
+        response has been collected.
+
+        This only needs to be called manually if using :meth:`listen` directly in a
+        custom collection loop: otherwise, it is called internally by :meth:`collect`.
+
+        """
+        self._loop_start = None
+
+
+
+class KeypressListener(BaseResponseListener):
+    """A convenience class for collecting keypress responses.
+
+    This listener collects keypress responses from the participant, with the
+    valid response keys and their corresponding output labels being specified
+    in a dictionary::
+
+      self.key_listener = KeypressListener({
+        "z": "left",
+        "/": "right",
+      })
+
+    The keys in the dictionary (e.g. 'z', '/') specify which keys to watch for
+    responses (other keys will be ignored). Their values (e.g. 'left', 'right')
+    specify their corresponding response labels if that key is pressed during
+    response collection.
+    
+    See the first column in `this table <https://wiki.libsdl.org/SDL2/SDL_Keycode>`_
+    for a full list of valid key names.
+
+    Args:
+        keymap (dict): A dictionary specifying the keys to check for and their
+            corresponding response labels.
+        timeout (float, optional): The maximum duration (in seconds) to wait for a
+            valid response.
+
+    """
+    def __init__(self, keymap, timeout=None):
+        super(KeypressListener, self).__init__(timeout)
+        self._keymap = self._parse_keymap(keymap)
+
+    def _timestamp(self):
+        # Since keypress events have SDL timestamps, use SDL_GetTicks to mark the
+        # start of the collection loop.
+        return sdl2.SDL_GetTicks()
+
+    def _parse_keymap(self, keymap):
+        # Perform basic validation of the keymap
+        if not isinstance(keymap, dict):
+            raise TypeError("keymap must be a properly-formatted dict.")
+        if len(keymap) == 0:
+            raise ValueError("keymap must contain at least one key/label pair.")
+        # Convert all key names in the map to SDL keycodes
+        keycode_map = {}
+        for key, label in keymap.items():
+            if type(key) is str:
+                keycode = sdl2.SDL_GetKeyFromName(key.encode('utf8'))
+            else:
+                keycode = key
+            if keycode == 0:
+                raise ValueError("'{0}' is not a recognized key name.".format(key))
+            keycode_map[keycode] = label
+
+        return keycode_map
+
+    def collect(self):
+        """Collects a single keypress response from the participant.
+
+        This method starts the response collection loop and waits until either a
+        response is made or the listener times out to return::
+
+           resp = self.key_listener.collect()
+           accuracy = resp.value == target
+           rt = resp.rt
+
+        If the listener times out before a response is made, the returned
+        Response object will have a value of ``None`` and a reaction time of -1.
+
+        Returns:
+            :obj:`klibs.KLResponseCollector.Response`: A Response object
+            containing the label and reaction time (in milliseconds) of the
+            response.
+        
+        """
+        super(KeypressListener, self).collect()
+
+    def listen(self, q):
+        """Checks a queue of input events for valid keypress responses.
+
+        Along with :meth:`init` and :meth:`cleanup`, this method can be used to
+        create custom response collection loops is cases where :meth:`collect`
+        doesn't offer enough flexibility. e.g.::
+
+            key_listener.init()
+
+            response = None
+            while not response:
+                q = pump()
+                ui_request(queue=q)
+                response = key_listener.listen(q)
+
+            key_listener.cleanup()
+
+        Args:
+            q (list): A list of input events to check for valid key responses.
+
+        Returns:
+            :obj:`klibs.KLResponseCollector.Response` or None: A Response object
+            containing the label and reaction time (in milliseconds) of the
+            response, or None if no response has been made.
+
+        """
+        # Checks the input queue for any keypress events for keys in the keymap
+        for event in q:
+            if event.type == sdl2.SDL_KEYDOWN:
+                key = event.key.keysym # keyboard button event object
+                if key.sym in self._keymap.keys():
+                    value = self._keymap[key.sym]
+                    rt = (event.key.timestamp - self._loop_start)
+                    return Response(value, rt)
+        return None

--- a/klibs/KLResponseListeners.py
+++ b/klibs/KLResponseListeners.py
@@ -1,4 +1,4 @@
-"""The ResponseListener Module
+"""
 
 The purpose of this module is to make it easy to collect responses of different types
 from participants (e.g. keypress responses, color wheel judgements). There are a number
@@ -84,12 +84,15 @@ methods::
 
 The ``init`` method sets the timestamp for the start of the collection loop and
 performs any other necessary setup for the listener (e.g. making sure the mouse
-cursor is visible for color wheel responses). The ``listen`` method checks a
-given event queue for response input, returning the response and reaction time
-if a valid response has been made or ``None`` otherwise. The ``cleanup`` method
-resets the start time for the listener and does any other necessary cleanup
-(e.g. re-hiding the cursor if it was originally hidden prior to collecting a
-color wheel response).
+cursor is visible for color wheel responses).
+
+The ``listen`` method checks a given event queue for response input, returning
+the response and reaction time if a valid response has been made or ``None``
+otherwise.
+
+The ``cleanup`` method resets the start time for the listener and does any other
+necessary cleanup (e.g. re-hiding the cursor if it was originally hidden prior
+to collecting a color wheel response).
 
 """
 
@@ -99,6 +102,9 @@ from klibs.KLTime import precise_time
 from klibs.KLEventQueue import pump, flush
 from klibs.KLUserInterface import ui_request
 
+# TODO: Add some sort of tests for elapsed, collect, timeout, callback?
+# TODO: Add tests for ColorWheelListener
+# TODO: Update changelog
 
 
 class BaseResponseListener(object):

--- a/klibs/KLResponseListeners.py
+++ b/klibs/KLResponseListeners.py
@@ -7,6 +7,7 @@ from klibs.KLResponseCollectors import Response
 
 # NOTE: Do away with Response class and just return two-item (value, rt) tuple?
 
+
 class BaseResponseListener(object):
     """An abstract base class for creating response listeners.
     
@@ -41,10 +42,9 @@ class BaseResponseListener(object):
         resp = None
         self.init()
         while not resp:
-            # Check if the collection loop has timed out
-            if self.timeout_ms:
-                if (self._timestamp() - self._loop_start) > self.timeout_ms:
-                    break
+            # End collection if the loop has timed out
+            if self.timed_out:
+                break
             # Fetch event queue and check for valid responses
             events = pump()
             ui_request(queue=events)
@@ -118,6 +118,27 @@ class BaseResponseListener(object):
 
         """
         self._loop_start = None
+
+    @property
+    def elapsed(self):
+        """float: The elapsed time (in ms) since response collection began.
+
+        If the listener's collection loop has not started yet, the elapsed time
+        will be 0.
+
+        """
+        if not self._loop_start:
+            return 0.0
+        return (self._timestamp() - self._loop_start)
+
+    @property
+    def timed_out(self):
+        """bool: Whether the current response collection loop has timed out.
+
+        """
+        if not self.timeout_ms:
+            return False
+        return self.elapsed > self.timeout_ms
 
 
 

--- a/klibs/KLUserInterface.py
+++ b/klibs/KLUserInterface.py
@@ -12,7 +12,7 @@ from sdl2.mouse import SDL_GetMouseState, SDL_GetMouseFocus, SDL_WarpMouseInWind
 from klibs import TK_S, TK_MS
 from klibs import P
 from klibs.KLTime import precise_time as time
-from klibs.KLEventQueue import pump
+from klibs.KLEventQueue import pump, flush
 
 
 def any_key(allow_mouse_click=True):
@@ -31,14 +31,22 @@ def any_key(allow_mouse_click=True):
             clicks in addition to key presses.
     
     """
-    any_key_pressed = False
-    while not any_key_pressed:
+    flush()
+    mouse_down = False
+    done = False
+    while not done:
         for event in pump(True):
             if event.type == SDL_KEYDOWN:
                 ui_request(event.key.keysym)
-                any_key_pressed = True
-            if event.type == SDL_MOUSEBUTTONUP and allow_mouse_click:
-                any_key_pressed = True
+                done = True
+                break
+            # For mouse, require both click and release to break loop
+            if allow_mouse_click:
+                if event.type == SDL_MOUSEBUTTONDOWN:
+                    mouse_down = True
+                if mouse_down and event.type == SDL_MOUSEBUTTONUP:
+                    done = True
+                    break
 
 
 def key_pressed(key=None, released=False, queue=None):

--- a/klibs/resources/template/experiment.py
+++ b/klibs/resources/template/experiment.py
@@ -13,9 +13,6 @@ class PROJECT_NAME(klibs.Experiment):
     def block(self):
         pass
 
-    def setup_response_collector(self):
-        pass
-
     def trial_prep(self):
         pass
 

--- a/klibs/tests/test_KLResponseListeners.py
+++ b/klibs/tests/test_KLResponseListeners.py
@@ -1,4 +1,5 @@
 import pytest
+import mock
 
 from klibs.KLGraphics import KLDraw as kld
 from klibs.KLResponseListeners import (
@@ -6,6 +7,16 @@ from klibs.KLResponseListeners import (
 )
 
 from eventfactory import keydown, click
+
+
+time_tmp = 1
+
+def mock_timestamp():
+    return time_tmp * 1000
+
+def add_time(secs):
+    global time_tmp
+    time_tmp += secs
 
 
 class TestKeypressListener(object):
@@ -18,6 +29,16 @@ class TestKeypressListener(object):
             tst = KeypressListener({})
         with pytest.raises(ValueError):
             tst = KeypressListener({'not_a_key': 'value'})
+
+    def test_elapsed(self):
+        listener = KeypressListener({'space': 'detection'})
+        with mock.patch.object(listener, '_timestamp', new=mock_timestamp):
+            assert listener.elapsed == 0
+            listener.init()
+            add_time(1.5)
+            assert listener.elapsed == 1500
+            listener.cleanup()
+            assert listener.elapsed == 0
 
     def test_listen(self):
         listener = KeypressListener({

--- a/klibs/tests/test_KLResponseListeners.py
+++ b/klibs/tests/test_KLResponseListeners.py
@@ -1,0 +1,33 @@
+import pytest
+
+from klibs.KLResponseListeners import KeypressListener
+
+from eventfactory import keydown
+
+
+class TestKeypressListener(object):
+
+    def test_init(self):
+        listener = KeypressListener({'space': 'detection'})
+        with pytest.raises(TypeError):
+            tst = KeypressListener(['space'])
+        with pytest.raises(ValueError):
+            tst = KeypressListener({})
+        with pytest.raises(ValueError):
+            tst = KeypressListener({'not_a_key': 'value'})
+
+    def test_listen(self):
+        listener = KeypressListener({
+            'z': 'left',
+            '/': 'right',
+        })
+        listener.init()
+        # Test detection of response keys
+        test_keys = [keydown('a'), keydown('z')]
+        assert listener.listen(test_keys).value == 'left'
+        test_keys = [keydown('/'), keydown('b')]
+        assert listener.listen(test_keys).value == 'right'
+        # Test that non-response keys are ignored
+        test_keys = [keydown('a'), keydown('b')]
+        assert not listener.listen(test_keys)
+        listener.cleanup()

--- a/klibs/tests/test_KLResponseListeners.py
+++ b/klibs/tests/test_KLResponseListeners.py
@@ -1,8 +1,8 @@
 import pytest
 
-from klibs.KLResponseListeners import KeypressListener
+from klibs.KLResponseListeners import KeypressListener, MouseButtonListener
 
-from eventfactory import keydown
+from eventfactory import keydown, click
 
 
 class TestKeypressListener(object):
@@ -24,10 +24,45 @@ class TestKeypressListener(object):
         listener.init()
         # Test detection of response keys
         test_keys = [keydown('a'), keydown('z')]
-        assert listener.listen(test_keys).value == 'left'
+        assert listener.listen(test_keys)[0] == 'left'
         test_keys = [keydown('/'), keydown('b')]
-        assert listener.listen(test_keys).value == 'right'
+        assert listener.listen(test_keys)[0] == 'right'
         # Test that non-response keys are ignored
         test_keys = [keydown('a'), keydown('b')]
         assert not listener.listen(test_keys)
+        listener.cleanup()
+
+
+class TestMouseButtonListener(object):
+
+    def test_init(self):
+        listener = MouseButtonListener({'left': 'detection'})
+        with pytest.raises(TypeError):
+            tst = MouseButtonListener(['left'])
+        with pytest.raises(ValueError):
+            tst = MouseButtonListener({})
+        with pytest.raises(ValueError):
+            tst = MouseButtonListener({'not_a_button': 'value'})
+
+    def test_listen(self):
+        listener = MouseButtonListener({
+            'left': 'same',
+            'right': 'different',
+        })
+        listener.init()
+        # Test detection of response clicks
+        test_clicks = [keydown('a'), click('middle'), click('left')]
+        assert listener.listen(test_clicks)[0] == 'same'
+        test_clicks = [click('middle'), click('right')]
+        assert listener.listen(test_clicks)[0] == 'different'
+        # Test that non-response buttons are ignored
+        test_clicks = [keydown('a'), click('middle')]
+        assert not listener.listen(test_clicks)
+        listener.cleanup()
+        # Test that all buttons registered when set to 'any'
+        listener = MouseButtonListener({'any': 'detection'})
+        listener.init()
+        assert listener.listen([click('left')])[0] == 'detection'
+        assert listener.listen([click('right')])[0] == 'detection'
+        assert listener.listen([click('middle')])[0] == 'detection'
         listener.cleanup()

--- a/klibs/tests/test_KLResponseListeners.py
+++ b/klibs/tests/test_KLResponseListeners.py
@@ -1,6 +1,9 @@
 import pytest
 
-from klibs.KLResponseListeners import KeypressListener, MouseButtonListener
+from klibs.KLGraphics import KLDraw as kld
+from klibs.KLResponseListeners import (
+    KeypressListener, MouseButtonListener, ColorWheelListener,
+)
 
 from eventfactory import keydown, click
 
@@ -65,4 +68,53 @@ class TestMouseButtonListener(object):
         assert listener.listen([click('left')])[0] == 'detection'
         assert listener.listen([click('right')])[0] == 'detection'
         assert listener.listen([click('middle')])[0] == 'detection'
+        listener.cleanup()
+
+
+class TestColorWheelListener(object):
+
+    def test_init(self):
+        # Test normal init
+        wheel = kld.ColorWheel(600)
+        listener = ColorWheelListener(wheel)
+        # Test specifying custom center
+        listener_c = ColorWheelListener(wheel, center=(300, 300))
+        # Test error when wheel isn't a color wheel
+        with pytest.raises(TypeError):
+            wheel = kld.Annulus(600, thickness=100)
+            tst = ColorWheelListener(wheel)
+
+    def test_set_target(self):
+        wheel = kld.ColorWheel(600)
+        listener = ColorWheelListener(wheel)
+        target = wheel.color_from_angle(90)
+        listener.set_target(target)
+        # Test error when colour not in wheel
+        with pytest.raises(ValueError):
+            listener.set_target((0, 0, 0))
+
+    def test_listen(self):
+        wheel = kld.ColorWheel(600, thickness=100)
+        listener = ColorWheelListener(wheel, center=(300, 300))
+        # Test error when trying to init before target color set
+        with pytest.raises(RuntimeError):
+            listener.init()
+        # Set a target color for the listener and init
+        target = wheel.color_from_angle(180)
+        listener.set_target(target)
+        listener.init()
+        # Test detection of response clicks
+        test_clicks = [keydown('a'), click(loc=(300, 550), release=True)]
+        angle_err, resp_color, rt = listener.listen(test_clicks)
+        assert resp_color == target[:3]
+        assert angle_err == 0
+        test_clicks = [click(loc=(50, 300), release=True)]
+        angle_err, resp_color, rt = listener.listen(test_clicks)
+        assert angle_err == -90
+        # Test that non-responses are ignored
+        test_clicks = [
+            click(loc=(300, 550), release=False), # Should ignore mouse down events
+            click(loc=(300, 300), release=True), # Should ignore off-wheel clicks
+        ]
+        assert not listener.listen(test_clicks)
         listener.cleanup()


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

Closes #27. This PR adds a new module, `KLResponseListener`, to supersede the existing `ResponseCollector` method of collecting responses from participants. It is designed to be much simpler, more flexible, and more Pythonic than the `KLResponseCollectors` module and its classes. `KLResponseCollectors` will still be left in for backwards compatibility with existing code, but shouldn't be used for any new projects.

The problem with `KLResponseCollectors` is that it's far too complicated for its own good. For example, using the current `ResponseCollector` class to collect a simple key detection response involves code like this, which is very hard to follow unless you know what `self.rc` is and how to specify all the possible options:
```python
self.rc.uses(KeyPressResponse)
self.rc.terminate_after = [10, TK_S]
self.rc.display_callback = self.response_callback
self.rc.keypress_listener.key_map = {' ': 'detection'}
self.rc.keypress_listener.interrupts = True
```
Note that some of these options are `self.rc` attributes and some are `self.rc.keypress_listener` attributes, making things very obtuse and to remember or document.

Then, to actually collect the response, you would need to call the `collect` method and then call a method of a *submodule* of `self.rc` to actually get the response value and reaction time:
```python
self.rc.collect()
response, rt = self.rc.keypress_listener.response()
```

By contrast, creating an equivalent keypress listener with the new `KeypressListener` class is much simpler and more readable:
```python
self.key_listener = KeypressListener(
    {' ': 'detection'}, timeout=10, loop_callback=self.response_callback
)
```
Likewise, collecting responses and retrieving the response values is now done in a single line:
```python
response, rt = self.key_listener.collect()
```

Currently, only 3 ResponseListeners have been implemented:
* `KeypressListener` for collecting keyboard responses
* `MouseButtonListener` for collecting mouse button responses
* `ColorWheelListener` for collecting colour wheel judgements

Additional ResponseListeners may be added in the future, but these three are by far the most commonly used. Equivalents of `AudioResponse` and `DrawResponse` have not been ported over from `KLResponseCollector` due to their niche use cases, but could be easily implemented as project-specific `BaseResponseListener` subclasses or added into `klibs` itself at a future date.

Further, the new `KLResponseListeners` module has extensive documentation and basic unit testing, both of which are a large improvement over `KLResponseCollectors`.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
