### PR TITLE
Add multi-row support for Database.insert

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -34,6 +34,11 @@ New Features:
   a friendlier, more readable way of adding events to the trial sequencer.
 * Added a convenience function :func:`~klibs.KLTime.time_msec` for getting
   timestamps in milliseconds.
+* The :meth:`~klibs.KLDatabase.Database.insert` method for the
+  :class:`~klibs.KLDatabase.Database` class now supports inserting multiple rows
+  at once via a list of dicts (one for each row). When inserting many rows of
+  data, this can offer substatial speedup over calling ``insert`` on each row
+  individually.
 
 
 Runtime Changes:

--- a/klibs/tests/test_KLDatabase.py
+++ b/klibs/tests/test_KLDatabase.py
@@ -97,9 +97,10 @@ class TestDatabase(object):
         last_row = db.last_row_id('participants')
         assert last_row == None
         data = generate_id_row()
-        db.insert(data, table='participants')
+        row_id = db.insert(data, table='participants')
         last_row = db.last_row_id('participants')
         assert last_row == 1
+        assert last_row == row_id
         # Test exception on non-existant table
         with pytest.raises(ValueError):
             db.insert(data, table='nope')
@@ -113,6 +114,15 @@ class TestDatabase(object):
         data = runtime_info_init()
         db.insert(data, table='session_info')
         assert db.last_row_id('session_info') == 1
+        # Test inserting multiple rows of data
+        rows = [generate_data_row(trial=i+1) for i in range(3)]
+        db.insert(rows, table='trials')
+        assert db.last_row_id('trials') == 3
+        retrieved = db.select('trials')
+        assert len(retrieved) == 3
+        # Test inserting an empty list of rows
+        db.insert([], table='trials')
+        assert db.last_row_id('trials') == 3
         # Test exception when unable to coerce value to column type
         data = generate_id_row(uid=3)
         data["age"] = "hello"


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

This PR adds adds multi-row insertion support to the `KLDatabase.Database.insert` method, providing massive speedups when inserting many rows of data at a a time.

Previously, inserting rows one-by-one would commit the changes to the database after every row, which is a slow I/O operation (especially on computers with slower storage). When inserting hundreds of rows at once, it could take over 2 seconds in some cases! With these changes, when providing multiple rows to `insert` in a list, the database changes are only committed once at the end, increasing performance to ~30ms for the same data that took over 2 seconds during testing.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
