### PR TITLE
Fix occasional evm eyelink issues & clean up __trial__

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -41,7 +41,12 @@ Fixed Bugs:
 
 * KLibs no longer crashes on launch with Python 3.12.
 * KLibs no longer briefly shows a blank screen when a trial is recycled.
-
+* When eye tracking, KLibs now starts the trial clock (`self.evm`) *after*
+  setting up the eye tracker to record. Previously tracker setup was run after
+  the clock was started, meaning that if the tracker took unexpectedly long to
+  initialize the trial could (on rare occasions) start with anywhere between 50
+  and 1000 ms already elapsed on the clock, making stimuli appear sooner than
+  expected.
 
 0.7.7b1
 -------

--- a/klibs/KLExperiment.py
+++ b/klibs/KLExperiment.py
@@ -96,7 +96,7 @@ class Experiment(EnvAgent):
         """
         Private method; manages a trial.
         """
-        from klibs.KLEventQueue import pump
+        from klibs.KLEventQueue import flush
         from klibs.KLUserInterface import show_cursor, hide_cursor
 
         # At start of every trial, before setup_response_collector or trial_prep are run, retrieve
@@ -105,34 +105,39 @@ class Experiment(EnvAgent):
         for iv, value in trial.items():
             setattr(self, iv, value)
 
-        pump()
+        # Run trial prep methods
         self.setup_response_collector()
         self.trial_prep()
-        tx = None
+        flush()
+
+        # Get everything ready to start the trial
+        trylink = P.eye_tracking and not P.eye_tracker_available
+        if P.development_mode and (P.dm_trial_show_mouse or trylink):
+            show_cursor()
+        if P.eye_tracking and not P.manual_eyelink_recording:
+            self.el.start(P.trial_number)
+        self.evm.start_clock()
+
+        # Actually run the trial and log the data to the database
+        recycle = None
         try:
-            if P.development_mode and (P.dm_trial_show_mouse or (P.eye_tracking and not P.eye_tracker_available)):
-                show_cursor()
-            self.evm.start_clock()
-            if P.eye_tracking and not P.manual_eyelink_recording:
-                self.el.start(P.trial_number)
             P.in_trial = True
             self.__log_trial__(self.trial())
             P.in_trial = False
-            if P.eye_tracking and not P.manual_eyelink_recording:
-                self.el.stop()
-            if P.development_mode and (P.dm_trial_show_mouse or (P.eye_tracking and not P.eye_tracker_available)):
-                hide_cursor()
-            self.evm.stop_clock()
-            self.trial_clean_up()
         except TrialException as e:
-            self.trial_clean_up()
-            self.evm.stop_clock()
-            tx = e
+            recycle = e
+
+        # Clean up after the trial
+        self.evm.stop_clock()
         if P.eye_tracking and not P.manual_eyelink_recording:
-            # todo: add a warning, here, if the recording hasn't been stopped when under manual control
             self.el.stop()
-        if tx:
-            raise tx
+        if P.development_mode and (P.dm_trial_show_mouse or trylink):
+            hide_cursor()
+        self.trial_clean_up()
+
+        # Recycle trial if TrialException encountered
+        if recycle:
+            raise recycle
 
 
     def __log_trial__(self, trial_data):


### PR DESCRIPTION
<!--Thanks for contributing to KLibs!-->

# PR Description

Closes #35. This PR fixes a bug where trial timing would be thrown off by varying amounts when using an EyeLink, due to the runtime code starting the trial clock (`self.evm`) before setting up the EyeLink to record, which could sometimes take over 1000 ms. The trial clock is now started immediately after EyeLink setup is complete.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [CHANGELOG.rst][changelog-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[changelog-file]: https://github.com/a-hurst/klibs/blob/master/docs/CHANGELOG.rst
